### PR TITLE
Multi-state queries and snapshotting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,9 +289,9 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "assert2"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b08f101feec0a9ef4ef850105353c3726da5db058e19b8c53a6ab1fc4b7f7e33"
+checksum = "eaf98d1183406dcb8f8b545e1f24829d75c1a9d35eec4b86309a22aa8b6d8e95"
 dependencies = [
  "assert2-macros",
  "is-terminal",
@@ -300,12 +300,13 @@ dependencies = [
 
 [[package]]
 name = "assert2-macros"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fabe93976c52f6ab5c8c356335953880c1030093b067500b13bd33ec0ea6377"
+checksum = "6c55bdf3e6f792f8f1c750bb6886b7ca40fa5a354ddb7a4dee550b93985a9235"
 dependencies = [
  "proc-macro2",
  "quote",
+ "rustc_version",
  "syn 1.0.109",
 ]
 
@@ -482,47 +483,26 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "0.10.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
+checksum = "bf617fabf5cdbdc92f774bfe5062d870f228b80056d41180797abf48bed4056e"
 dependencies = [
  "borsh-derive",
- "hashbrown 0.13.2",
+ "cfg_aliases",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "0.10.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0754613691538d51f329cce9af41d7b7ca150bc973056f1156611489475f54f7"
+checksum = "f404657a7ea7b5249e36808dff544bc88a28f26e0ac40009f674b7a009d14be3"
 dependencies = [
- "borsh-derive-internal",
- "borsh-schema-derive-internal",
+ "once_cell",
  "proc-macro-crate",
  "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-derive-internal"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb438156919598d2c7bad7e1c0adf3d26ed3840dbc010db1a882a65583ca2fb"
-dependencies = [
- "proc-macro2",
  "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-schema-derive-internal"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634205cc43f74a1b9046ef87c4540ebda95696ec0f315024860cad7c5b0f5ccd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "syn 2.0.39",
+ "syn_derive",
 ]
 
 [[package]]
@@ -626,6 +606,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "const-oid"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,8 +645,9 @@ dependencies = [
  "dotenv",
  "opentelemetry",
  "opentelemetry-jaeger",
- "prost 0.12.1",
+ "prost 0.12.3",
  "rust_decimal",
+ "serde",
  "sqlx",
  "thiserror",
  "tokio",
@@ -776,9 +763,9 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -788,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "disintegrate"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "assert2",
  "async-trait",
@@ -797,6 +784,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "mockall",
+ "paste",
  "regex",
  "serde",
  "thiserror",
@@ -804,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "disintegrate-macros"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "disintegrate",
  "heck",
@@ -815,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "disintegrate-postgres"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -823,20 +811,23 @@ dependencies = [
  "disintegrate-macros",
  "disintegrate-serde",
  "futures",
+ "md-5",
+ "paste",
  "serde",
  "serde_json",
  "sqlx",
  "thiserror",
  "tokio",
  "tokio-util",
+ "uuid",
 ]
 
 [[package]]
 name = "disintegrate-serde"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "apache-avro",
- "prost 0.12.1",
+ "prost 0.12.3",
  "protobuf",
  "serde",
  "serde_json",
@@ -1517,18 +1508,19 @@ checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
 name = "md-5"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
+ "cfg-if",
  "digest",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "mime"
@@ -1692,9 +1684,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opentelemetry"
@@ -1801,9 +1793,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pem-rfc7468"
@@ -1852,9 +1844,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -1947,11 +1939,34 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "0.1.5"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
- "toml",
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -1975,12 +1990,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fdd22f3b9c31b53c060df4a0613a1c7f062d4115a2b984dd15b1858f7e340d"
+checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
 dependencies = [
  "bytes",
- "prost-derive 0.12.1",
+ "prost-derive 0.12.3",
 ]
 
 [[package]]
@@ -2019,7 +2034,7 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease 0.2.9",
- "prost 0.12.1",
+ "prost 0.12.3",
  "prost-types 0.12.1",
  "regex",
  "syn 2.0.39",
@@ -2042,9 +2057,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "265baba7fabd416cf5078179f7d2cbeca4ce7a9041111900675ea7c4cb8a4c32"
+checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2068,7 +2083,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e081b29f63d83a4bc75cfc9f3fe424f9156cf92d8a4f0c9407cce9a1b67327cf"
 dependencies = [
- "prost 0.12.1",
+ "prost 0.12.3",
 ]
 
 [[package]]
@@ -2173,9 +2188,21 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.1"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2184,9 +2211,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "rend"
@@ -2282,9 +2309,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.32.0"
+version = "1.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c4216490d5a413bc6d10fa4742bd7d4955941d062c0ef873141d6b0e7b30fd"
+checksum = "06676aec5ccb8fc1da723cc8c0f9a46549f21ebb8753d3915c6c41db1e7f1dc4"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -2397,18 +2424,18 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.190"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.190"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2609,6 +2636,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
+ "uuid",
  "webpki-roots",
 ]
 
@@ -2690,6 +2718,7 @@ dependencies = [
  "stringprep",
  "thiserror",
  "tracing",
+ "uuid",
  "whoami",
 ]
 
@@ -2729,6 +2758,7 @@ dependencies = [
  "stringprep",
  "thiserror",
  "tracing",
+ "uuid",
  "whoami",
 ]
 
@@ -2752,6 +2782,7 @@ dependencies = [
  "sqlx-core",
  "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -2809,6 +2840,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2981,9 +3024,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2994,12 +3037,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.5.11"
+name = "toml_datetime"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+
+[[package]]
+name = "toml_edit"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "serde",
+ "indexmap 2.1.0",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -3021,7 +3072,7 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.12.1",
+ "prost 0.12.3",
  "tokio",
  "tokio-stream",
  "tower",
@@ -3063,7 +3114,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f80db390246dfb46553481f6024f0082ba00178ea495dbb99e70ba9a4fafb5e1"
 dependencies = [
  "async-stream",
- "prost 0.12.1",
+ "prost 0.12.3",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -3075,7 +3126,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fa37c513df1339d197f4ba21d28c918b9ef1ac1768265f11ecb6b7f1cba1b76"
 dependencies = [
- "prost 0.12.1",
+ "prost 0.12.3",
  "prost-types 0.12.1",
  "tokio",
  "tokio-stream",
@@ -3253,10 +3304,11 @@ checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 
 [[package]]
 name = "uuid"
-version = "1.3.3"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
+checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
+ "md-5",
  "serde",
 ]
 
@@ -3530,6 +3582,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ authors = [
 readme = "README.md"
 
 [workspace]
+resolver = "2"
 members = [
 	".",
 	"disintegrate",

--- a/disintegrate-macros/Cargo.toml
+++ b/disintegrate-macros/Cargo.toml
@@ -21,4 +21,4 @@ quote = "1.0.33"
 syn = { version = "2.0.39", features = ["full"] }
 
 [dev-dependencies]
-disintegrate = { version = "0.6.0", path = "../disintegrate" }
+disintegrate = { version = "0.6.0", path = "../disintegrate", features = ["macros"] }

--- a/disintegrate-macros/Cargo.toml
+++ b/disintegrate-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "disintegrate-macros"
 description = "Disintegrate macros. Not for direct use. Refer to the `disintegrate` crate for details."
-version = "0.4.0"
+version = "0.6.0"
 license.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -21,4 +21,4 @@ quote = "1.0.33"
 syn = { version = "2.0.39", features = ["full"] }
 
 [dev-dependencies]
-disintegrate = { version = "0.5.0", path = "../disintegrate" }
+disintegrate = { version = "0.6.0", path = "../disintegrate" }

--- a/disintegrate-macros/src/lib.rs
+++ b/disintegrate-macros/src/lib.rs
@@ -1,8 +1,12 @@
 mod event;
+mod state_query;
+mod symbol;
 
 extern crate proc_macro;
 
 use proc_macro::TokenStream;
+use proc_macro2::{Ident, TokenStream as TokenStream2};
+
 use syn::{parse_macro_input, DeriveInput};
 
 /// Derives the `Event` trait for an enum, allowing it to be used as an event in Disintegrate.
@@ -17,7 +21,7 @@ use syn::{parse_macro_input, DeriveInput};
 /// # Example
 ///
 /// ```rust
-/// use disintegrate_macros::Event;
+/// use disintegrate::Event;
 ///
 /// #[derive(Event)]
 /// #[group(UserEvent, [UserRegistered, UserUpdated])]
@@ -49,8 +53,73 @@ use syn::{parse_macro_input, DeriveInput};
 /// In this example, the `OrderEvent` enum is marked as an event by deriving the `Event` trait. The
 /// `#[group]` attribute specifies the event group name and the list of variants to include in the group, while the `#[id]` attribute is used
 /// to specify the domain identifiers of each variant.
-#[proc_macro_derive(Event, attributes(id, group))]
+#[proc_macro_derive(Event, attributes(group, id))]
 pub fn event(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
     event::event_inner(&ast)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
+/// Derives the `StateQuery` trait for a struct, enabling its use as a state query in Disintegrate.
+///
+/// The `state_query` attribute is mandatory and must include the event type associated with the state query.
+/// Additionally, the `id` attribute can be utilized to specify the domain identifier of a state query. It is employed
+/// in generating a stream query for the state, querying for the event specified in the `state_query`
+/// attribute, with the identifiers marked in `or`.
+///
+/// It is also possible to rename a state using the `rename` argument in the `state_query` attribute. This feature is beneficial
+/// for snapshotting, and the name specified in `rename` is used to identify the snapshot.
+///
+/// # Example
+///
+/// ```rust
+/// # use disintegrate::Event;
+/// # #[derive(Event, Clone)]
+/// # enum DomainEvent{
+/// #    UserCreated {
+/// #         #[id]
+/// #         user_id: String,
+/// #     },
+/// # }
+///
+/// use disintegrate::StateQuery;
+///
+/// #[derive(StateQuery, Clone)]
+/// #[state_query(DomainEvent, rename = "user-query-v1")] // Rename the state for snapshotting
+/// struct UserStateQuery {
+///     #[id]
+///     user_id: String,
+///     name: String
+/// }
+/// ```
+///
+/// In this example, the `UserStateQuery` struct is annotated with the `StateQuery` derive,
+/// indicating its role as a state query. The `#[state_query]` attribute specifies the associated event type,
+/// and the `#[id]` attribute is used to define the domain identifiers. The `#[state_query]` attribute with `rename`
+/// renames the state to 'user-query-v1' for snapshotting purposes.
+#[proc_macro_derive(StateQuery, attributes(state_query, id))]
+pub fn state_query(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    state_query::state_query_inner(&ast)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
+fn reserved_identifier_names(identifiers_fields: &[&Ident]) -> Option<TokenStream2> {
+    const RESERVED_NAMES: &[&str] = &["event_id", "payload", "event_type", "inserted_at"];
+
+    if let Some(identifier) = identifiers_fields
+        .iter()
+        .find(|id| RESERVED_NAMES.contains(&id.to_string().as_str()))
+    {
+        return Some(
+            syn::Error::new(
+                identifier.span(),
+                "Reserved domain identifier name. Please use a different name",
+            )
+            .to_compile_error(),
+        );
+    }
+    None
 }

--- a/disintegrate-macros/src/state_query.rs
+++ b/disintegrate-macros/src/state_query.rs
@@ -1,0 +1,156 @@
+use proc_macro2::{Ident, TokenStream};
+use quote::quote;
+use syn::parse::{Parse, ParseStream};
+use syn::token::Comma;
+use syn::{Data, DeriveInput, Error};
+use syn::{DataStruct, LitStr};
+
+use crate::symbol::{ID, RENAME, STATE_QUERY};
+
+enum StateQueryOptionalArgs {
+    Rename(LitStr),
+}
+
+impl Parse for StateQueryOptionalArgs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let name = input.parse::<Ident>()?;
+        input.parse::<syn::token::Eq>()?;
+
+        if name == RENAME {
+            let value = input.parse::<LitStr>()?;
+            return Ok(Self::Rename(value));
+        }
+
+        Err(Error::new(name.span(), "invalid argument"))
+    }
+}
+
+struct StateQueryArgs {
+    event: Ident,
+    optional_args: Vec<StateQueryOptionalArgs>,
+}
+
+impl Parse for StateQueryArgs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let event = input.parse::<Ident>()?;
+
+        let comma = input.parse::<Comma>().ok();
+
+        let mut optional_args: Vec<StateQueryOptionalArgs> = vec![];
+        if comma.is_some() {
+            optional_args = input
+                .parse_terminated(StateQueryOptionalArgs::parse, Comma)?
+                .into_iter()
+                .collect();
+        }
+
+        Ok(Self {
+            event,
+            optional_args,
+        })
+    }
+}
+
+pub fn state_query_inner(ast: &DeriveInput) -> Result<TokenStream, Error> {
+    match ast.data {
+        Data::Struct(ref data) => impl_struct(ast, data),
+        _ => panic!("Not supported type"),
+    }
+}
+
+fn impl_struct(ast: &DeriveInput, data: &DataStruct) -> syn::Result<TokenStream> {
+    let state_query_ident = ast.ident.clone();
+
+    let state_query_attrs: Vec<_> = ast
+        .attrs
+        .iter()
+        .filter(|attr| attr.path() == STATE_QUERY)
+        .collect();
+
+    if state_query_attrs.len() != 1 {
+        return Err(Error::new(
+            state_query_ident.span(),
+            "expected a `state` attribute",
+        ));
+    }
+
+    let state_query_attrs = state_query_attrs
+        .first()
+        .unwrap()
+        .parse_args::<StateQueryArgs>()?;
+    let event_type = state_query_attrs.event;
+    let state_query_name = state_query_attrs
+        .optional_args
+        .iter()
+        .map(|attrs| {
+            let StateQueryOptionalArgs::Rename(rename) = attrs;
+            rename.value()
+        })
+        .last()
+        .unwrap_or_else(|| state_query_ident.to_string());
+
+    let identifiers_fields: Vec<_> = data
+        .fields
+        .iter()
+        .filter(|f| f.attrs.iter().any(|attr| attr.path() == ID))
+        .flat_map(|f| f.ident.as_ref())
+        .collect();
+
+    let state_query = impl_state_query(event_type.clone(), &identifiers_fields);
+
+    Ok(quote! {
+        impl disintegrate::StateQuery for #state_query_ident {
+            const NAME: &'static str = #state_query_name;
+
+            type Event = #event_type;
+
+            fn query(&self) -> disintegrate::StreamQuery<Self::Event> {
+                #state_query
+            }
+        }
+
+        impl<E> From<#state_query_ident> for disintegrate::StreamQuery<E>
+        where E: disintegrate::Event + Clone, <#state_query_ident as disintegrate::StateQuery>::Event: Into<E>
+         {
+            fn from(state: #state_query_ident) -> Self {
+                disintegrate::query(Some(state.query().filter().clone()))
+            }
+        }
+
+        impl #state_query_ident {
+            pub fn exclude_events(&self, types: &'static [&'static str]) -> disintegrate::StreamQuery<<Self as disintegrate::StateQuery>::Event> {
+                self.query().exclude_events(types)
+            }
+        }
+
+    })
+}
+
+fn impl_state_query(event_type: Ident, identifiers_fields: &[&Ident]) -> TokenStream {
+    if identifiers_fields.is_empty() {
+        quote! {
+            disintegrate::query!(#event_type)
+        }
+    } else {
+        let filters = impl_state_filters(identifiers_fields);
+        quote! {
+            disintegrate::query!(#event_type, #filters)
+        }
+    }
+}
+
+fn impl_state_filters(identifiers_fields: &[&Ident]) -> Option<TokenStream> {
+    if identifiers_fields.is_empty() {
+        return None;
+    }
+
+    if identifiers_fields.len() == 1 {
+        Some(quote! {#(#identifiers_fields == self.#identifiers_fields)*})
+    } else {
+        let first = identifiers_fields[0];
+        let rest = impl_state_filters(&identifiers_fields[1..]);
+        Some(quote! {
+            ( #first == self.#first ) or ( #rest )
+        })
+    }
+}

--- a/disintegrate-macros/src/symbol.rs
+++ b/disintegrate-macros/src/symbol.rs
@@ -1,0 +1,39 @@
+use std::fmt::{self, Display};
+use syn::{Ident, Path};
+
+#[derive(Copy, Clone)]
+pub struct Symbol(&'static str);
+
+pub const RENAME: Symbol = Symbol("rename");
+pub const STATE_QUERY: Symbol = Symbol("state_query");
+pub const ID: Symbol = Symbol("id");
+
+impl PartialEq<Symbol> for Ident {
+    fn eq(&self, word: &Symbol) -> bool {
+        self == word.0
+    }
+}
+
+impl<'a> PartialEq<Symbol> for &'a Ident {
+    fn eq(&self, word: &Symbol) -> bool {
+        *self == word.0
+    }
+}
+
+impl PartialEq<Symbol> for Path {
+    fn eq(&self, word: &Symbol) -> bool {
+        self.is_ident(word.0)
+    }
+}
+
+impl<'a> PartialEq<Symbol> for &'a Path {
+    fn eq(&self, word: &Symbol) -> bool {
+        self.is_ident(word.0)
+    }
+}
+
+impl Display for Symbol {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str(self.0)
+    }
+}

--- a/disintegrate-macros/tests/event.rs
+++ b/disintegrate-macros/tests/event.rs
@@ -1,5 +1,4 @@
 use disintegrate::{ident, Event};
-use disintegrate_macros::Event;
 
 #[derive(Event, Clone, Debug, PartialEq, Eq)]
 struct UserUpdated {

--- a/disintegrate-postgres/Cargo.toml
+++ b/disintegrate-postgres/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "disintegrate-postgres"
 description = "Disintegrate PostgresDB implementation. Not for direct use. Refer to the `disintegrate` crate for details."
-version = "0.5.0"
+version = "0.6.0"
 license.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -13,18 +13,21 @@ default = []
 listener = ["dep:tokio", "dep:tokio-util"]
 
 [dependencies]
-disintegrate = { version = "0.5.0", path = "../disintegrate" }
-disintegrate-serde = { version = "0.2.0", path = "../disintegrate-serde" }
-disintegrate-macros = { version = "0.4.0", path = "../disintegrate-macros" }
+disintegrate = { version = "0.6.0", path = "../disintegrate" }
+disintegrate-serde = { version = "0.2.1", path = "../disintegrate-serde" }
+disintegrate-macros = { version = "0.6.0", path = "../disintegrate-macros" }
 serde = "1.0.190"
 serde_json = "1.0.108"
-sqlx = { version = "0.7.2", features = ["postgres", "runtime-tokio-rustls"] }
+sqlx = { version = "0.7.2", features = ["postgres", "runtime-tokio-rustls", "uuid"] }
 async-trait = "0.1.74"
 futures = "0.3.29"
 async-stream = "0.3.5"
 thiserror = "1.0.50"
 tokio = {version = "1.29.1", features = ["macros"], optional = true}
-tokio-util = {version = "0.7.8", optional = true}
+tokio-util = {version = "0.7.10", optional = true}
+uuid = { version = "1.6.1", features = ["v3"] }
+md-5 = "0.10.6"
+paste = "1.0.14"
 
 [dev-dependencies]
-disintegrate-serde = { version = "0.2.0", path = "../disintegrate-serde", features = ["json"] }
+disintegrate-serde = { version = "0.2.1", path = "../disintegrate-serde", features = ["json"] }

--- a/disintegrate-postgres/src/lib.rs
+++ b/disintegrate-postgres/src/lib.rs
@@ -3,8 +3,58 @@ mod error;
 mod event_store;
 #[cfg(feature = "listener")]
 mod listener;
+mod snapshotter;
 
 pub use crate::event_store::PgEventStore;
 #[cfg(feature = "listener")]
 pub use crate::listener::{PgEventListener, PgEventListenerConfig};
+pub use crate::snapshotter::PgSnapshotter;
+use disintegrate::{DecisionMaker, EventSourcedDecisionStateStore, NoSnapshot, WithSnapshot};
+use disintegrate_serde::Serde;
 pub use error::Error;
+
+/// An alias for [`DecisionMaker`], specialized for Postgres.
+pub type PgDecisionMaker<E, S, SN> =
+    DecisionMaker<EventSourcedDecisionStateStore<PgEventStore<E, S>, SN>>;
+
+/// An alias for [`WithSnapshot`], specialized for Postgres.
+pub type WithPgSnapshot = WithSnapshot<PgSnapshotter>;
+
+/// Creates a decision maker specialized for Postgres with snapshotting.
+/// The `every` parameter determines the frequency of snapshot creation, indicating the number of events
+/// between consecutive snapshots.
+///
+/// # Arguments
+///
+/// - `event_store`: An instance of `PgEventStore`.
+/// - `every`: The frequency of snapshot creation, specified as the number of events between consecutive snapshots.
+///
+/// # Returns
+///
+/// A `PgDecisionMaker` with snapshotting configured using the provided snapshot frequency.
+pub async fn decision_maker_with_snapshot<E: Clone, S: Serde<E> + Clone + Sync + Send>(
+    event_store: PgEventStore<E, S>,
+    every: u64,
+) -> Result<PgDecisionMaker<E, S, WithPgSnapshot>, Error> {
+    let pool = event_store.pool.clone();
+    let snapshot = WithSnapshot::new(PgSnapshotter::new(pool, every).await?);
+    Ok(DecisionMaker::new(EventSourcedDecisionStateStore::new(
+        event_store,
+        snapshot,
+    )))
+}
+
+/// Creates a decision maker specialized for Postgres without snapshotting.
+///
+/// # Arguments
+///
+/// - `event_store`: An instance of `PgEventStore`.
+///
+/// # Returns
+///
+/// A `PgDecisionMaker` without snapshotting.
+pub fn decision_maker<E: Clone, S: Serde<E> + Clone + Sync + Send>(
+    event_store: PgEventStore<E, S>,
+) -> PgDecisionMaker<E, S, NoSnapshot> {
+    DecisionMaker::new(EventSourcedDecisionStateStore::new(event_store, NoSnapshot))
+}

--- a/disintegrate-postgres/src/listener.rs
+++ b/disintegrate-postgres/src/listener.rs
@@ -294,7 +294,7 @@ where
             .event_handler
             .query()
             .clone()
-            .change_origin(last_processed_event_id + 1);
+            .change_origin(last_processed_event_id);
         let mut events_stream = self.event_store.stream(&query).take(self.config.batch_size);
 
         while let Some(event) = events_stream.next().await {
@@ -344,7 +344,7 @@ where
 
     async fn init(&self) -> Result<(), Error> {
         let mut tx = self.event_store.pool.begin().await?;
-        sqlx::query("INSERT INTO event_listener (id, last_processed_event_id) VALUES ($1, -1) ON CONFLICT (id) DO NOTHING")
+        sqlx::query("INSERT INTO event_listener (id, last_processed_event_id) VALUES ($1, 0) ON CONFLICT (id) DO NOTHING")
                 .bind(self.event_handler.id())
                 .execute(&mut *tx)
                 .await?;

--- a/disintegrate-postgres/src/snapshotter.rs
+++ b/disintegrate-postgres/src/snapshotter.rs
@@ -1,0 +1,126 @@
+//! # PostgreSQL Snapshotter
+//!
+//! This module provides an implementation of the `Snapshotter` trait using PostgreSQL as the underlying storage.
+//! It allows storing and retrieving snapshots from a PostgreSQL database.
+use async_trait::async_trait;
+use disintegrate::stream_query::StreamFilter;
+use disintegrate::{BoxDynError, IntoState, StateSnapshotter};
+use disintegrate::{StatePart, StateQuery};
+use md5::{Digest, Md5};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use sqlx::PgPool;
+use sqlx::Row;
+use uuid::Uuid;
+
+use crate::Error;
+
+#[cfg(test)]
+mod tests;
+
+/// PostgreSQL implementation for the `Snapshotter` trait.
+///
+/// The `PgSnapshotter` struct implements the `Snapshotter` trait for PostgreSQL databases.
+/// It allows for stroring and retrieving snapshots of `StateQuery` from PostgreSQL database.
+#[derive(Clone)]
+pub struct PgSnapshotter {
+    pool: PgPool,
+    every: u64,
+}
+
+impl PgSnapshotter {
+    /// Creates a new instance of `PgSnapshotter` with the specified PostgreSQL connection pool and snapshot frequency.
+    ///
+    /// # Arguments
+    ///
+    /// - `pool`: A PostgreSQL connection pool (`PgPool`) representing the database connection.
+    /// - `every`: The frequency of snapshot creation, specified as the number of events between consecutive snapshots.
+    ///
+    /// # Returns
+    ///
+    /// A new `PgSnapshotter` instance.
+    pub async fn new(pool: PgPool, every: u64) -> Result<Self, Error> {
+        setup(&pool).await?;
+        Ok(Self { pool, every })
+    }
+}
+
+#[async_trait]
+impl StateSnapshotter for PgSnapshotter {
+    async fn load_snapshot<S>(&self, default: StatePart<S>) -> StatePart<S>
+    where
+        S: Send + Sync + DeserializeOwned + StateQuery + 'static,
+    {
+        let query = query_key(default.query().filter());
+        let stored_snapshot =
+            sqlx::query("SELECT name, query, payload, version FROM snapshot where id = $1")
+                .bind(snapshot_id(S::NAME, &query))
+                .fetch_one(&self.pool)
+                .await;
+        if let Ok(row) = stored_snapshot {
+            let snapshot_name: String = row.get(0);
+            let snapshot_query: String = row.get(1);
+            if S::NAME == snapshot_name && query == snapshot_query {
+                let payload = serde_json::from_str(row.get(2)).unwrap_or(default.into_state());
+                return StatePart::new(row.get(3), payload);
+            }
+        }
+
+        default
+    }
+
+    async fn store_snapshot<S>(&self, state: &StatePart<S>) -> Result<(), BoxDynError>
+    where
+        S: Send + Sync + Serialize + StateQuery + 'static,
+    {
+        if state.applied_events() <= self.every {
+            return Ok(());
+        }
+        let query = query_key(state.query().filter());
+        let id = snapshot_id(S::NAME, &query);
+        let version = state.version();
+        let payload = serde_json::to_string(&state.clone().into_state())?;
+        sqlx::query("INSERT INTO snapshot (id, name, query, payload, version) VALUES ($1,$2,$3,$4,$5) ON CONFLICT(id) DO UPDATE SET name = $2, query = $3, payload = $4, version = $5 WHERE snapshot.version < $5")
+        .bind(id)
+        .bind(S::NAME)
+        .bind(query)
+        .bind(payload)
+        .bind(version)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+}
+
+fn snapshot_id(state_name: &str, query: &str) -> Uuid {
+    let mut hasher = Md5::new();
+    hasher.update(state_name);
+
+    uuid::Uuid::new_v3(
+        &uuid::Uuid::from_bytes(hasher.finalize().into()),
+        query.as_bytes(),
+    )
+}
+
+fn query_key(filter: &StreamFilter) -> String {
+    match filter {
+        StreamFilter::Events { names } => {
+            format!("({})", names.join(","))
+        }
+        StreamFilter::ExcludeEvents { names } => {
+            format!("not({})", names.join(","))
+        }
+        StreamFilter::Eq { ident, value } => format!("{ident}={value}"),
+        StreamFilter::And { l, r } => format!("{}&{}", query_key(l), query_key(r)),
+        StreamFilter::Or { l, r } => format!("{}|{}", query_key(l), query_key(r)),
+        StreamFilter::Origin { id } => format!(">={id}"),
+    }
+}
+
+pub async fn setup(pool: &PgPool) -> Result<(), Error> {
+    sqlx::query(include_str!("snapshotter/sql/table_snapshot.sql"))
+        .execute(pool)
+        .await?;
+    Ok(())
+}

--- a/disintegrate-postgres/src/snapshotter/sql/table_snapshot.sql
+++ b/disintegrate-postgres/src/snapshotter/sql/table_snapshot.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS snapshot (
+    id uuid PRIMARY KEY,
+    name text,
+    query text,
+    version bigint,
+    payload text,
+    inserted_at TIMESTAMP DEFAULT now()
+);

--- a/disintegrate-postgres/src/snapshotter/tests.rs
+++ b/disintegrate-postgres/src/snapshotter/tests.rs
@@ -1,0 +1,133 @@
+use disintegrate::{
+    domain_identifiers, query, DomainIdentifierSet, Event, EventSchema, IntoState, IntoStatePart,
+    PersistedEvent, StateMutate,
+};
+use disintegrate_serde::{serde::json::Json, Deserializer};
+use serde::Deserialize;
+use sqlx::PgPool;
+
+use super::*;
+
+#[derive(Clone)]
+enum CartEvent {
+    #[allow(dead_code)]
+    ItemAdded { cart_id: String, item_id: String },
+}
+
+impl Event for CartEvent {
+    const SCHEMA: EventSchema = EventSchema {
+        types: &["CartEventItemAdded"],
+        domain_identifiers: &["cart_id", "item_id"],
+    };
+    fn name(&self) -> &'static str {
+        match self {
+            CartEvent::ItemAdded { .. } => "CartProductAdded",
+        }
+    }
+    fn domain_identifiers(&self) -> DomainIdentifierSet {
+        match self {
+            CartEvent::ItemAdded {
+                item_id, cart_id, ..
+            } => domain_identifiers! {item_id: item_id, cart_id: cart_id},
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct CartState {
+    cart_id: String,
+    items: Vec<String>,
+}
+
+impl CartState {
+    fn new<const N: usize>(cart_id: &str, items: [&str; N]) -> Self {
+        Self {
+            cart_id: cart_id.to_string(),
+            items: items.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+}
+
+impl StateQuery for CartState {
+    const NAME: &'static str = "cart-state";
+    type Event = CartEvent;
+
+    fn query(&self) -> disintegrate::StreamQuery<Self::Event> {
+        query!(CartEvent, cart_id == self.cart_id)
+    }
+}
+
+impl StateMutate for CartState {
+    fn mutate(&mut self, event: Self::Event) {
+        match event {
+            CartEvent::ItemAdded { item_id, .. } => self.items.push(item_id),
+        }
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct SnapshotRow {
+    id: Uuid,
+    name: String,
+    query: String,
+    version: i64,
+    payload: String,
+}
+
+#[sqlx::test]
+async fn it_stores_snapshots(pool: PgPool) {
+    let snapshotter = PgSnapshotter::new(pool.clone(), 0).await.unwrap();
+    let mut state = CartState::new("c1", []).into_state_part();
+
+    state.mutate_part(PersistedEvent::new(
+        1,
+        CartEvent::ItemAdded {
+            cart_id: "c1".to_string(),
+            item_id: "p1".to_string(),
+        },
+    ));
+
+    snapshotter.store_snapshot(&state.clone()).await.unwrap();
+
+    let stored_snapshot = sqlx::query_as::<_, SnapshotRow>("SELECT * FROM snapshot")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    let query_key = query_key(state.query().filter());
+    let snapshot_id = snapshot_id(CartState::NAME, &query_key);
+    assert_eq!(stored_snapshot.id, snapshot_id);
+    assert_eq!(stored_snapshot.name, CartState::NAME);
+    assert_eq!(stored_snapshot.query, query_key);
+    assert_eq!(
+        Json::<CartState>::default()
+            .deserialize(stored_snapshot.payload.into_bytes())
+            .unwrap(),
+        state.into_state()
+    );
+    assert_eq!(stored_snapshot.version, 1);
+}
+
+#[sqlx::test]
+async fn it_loads_snapshots(pool: PgPool) {
+    let snapshotter = PgSnapshotter::new(pool.clone(), 2).await.unwrap();
+    let default_state = CartState::new("c1", []);
+    let expected_state = CartState::new("c1", ["p1", "p2"]);
+    let query_key = query_key(default_state.query().filter());
+    let snapshot_id = snapshot_id(CartState::NAME, &query_key);
+    sqlx::query("INSERT INTO snapshot (id, name, query, payload, version) VALUES ($1,$2,$3,$4,$5) ON CONFLICT(id) DO UPDATE SET name = $2, query = $3, payload = $4, version = $5 WHERE snapshot.version < $5")
+        .bind(snapshot_id)
+        .bind(CartState::NAME)
+        .bind(query_key)
+        .bind(serde_json::to_string(&expected_state).unwrap())
+        .bind(3)
+        .execute(&pool)
+        .await.unwrap();
+
+    let loaded_state = snapshotter
+        .load_snapshot(default_state.into_state_part())
+        .await;
+
+    assert_eq!(loaded_state.version(), 3);
+    assert_eq!(loaded_state.into_state(), expected_state);
+}

--- a/disintegrate-serde/Cargo.toml
+++ b/disintegrate-serde/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "disintegrate-serde"
 description = "Serialization and deserializaion library for Disintegrate event store. Not for direct use. Refer to the `disintegrate` crate for details."
-version = "0.2.0"
+version = "0.2.1"
 license.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -22,4 +22,4 @@ serde_json = { version = "1.0.108", optional = true }
 serde = { version = "1.0.190", features = ["derive"] }
 protobuf = { version = "3.3.0", optional = true }
 apache-avro = { version = "0.14.0", optional = true }
-prost = {version = "0.12.1", optional = true}
+prost = {version = "0.12.3", optional = true}

--- a/disintegrate-serde/src/serde.rs
+++ b/disintegrate-serde/src/serde.rs
@@ -18,7 +18,7 @@ pub enum Error {
     Conversion,
 }
 
-/// The `Serializer` trait defines the behavior for serializing values of type `T`.
+/// Defines the behavior for serializing values of type `T`.
 pub trait Serializer<T> {
     /// Serializes a value of type `T` into a byte vector.
     ///
@@ -32,7 +32,7 @@ pub trait Serializer<T> {
     fn serialize(&self, value: T) -> Vec<u8>;
 }
 
-/// The `Deserializer` trait defines the behavior for deserializing values of type `T`.
+/// Defines the behavior for deserializing values of type `T`.
 pub trait Deserializer<T> {
     /// Deserializes a byte vector into a value of type `T`.
     ///
@@ -46,7 +46,7 @@ pub trait Deserializer<T> {
     fn deserialize(&self, data: Vec<u8>) -> Result<T, Error>;
 }
 
-/// The `Serde` trait combines the `Serializer` and `Deserializer` traits for convenience.
+/// Combines the `Serializer` and `Deserializer` traits for convenience.
 pub trait Serde<T>: Serializer<T> + Deserializer<T> {}
 
 impl<K, T> Serde<T> for K where K: Serializer<T> + Deserializer<T> {}

--- a/disintegrate-serde/src/serde/json.rs
+++ b/disintegrate-serde/src/serde/json.rs
@@ -1,3 +1,4 @@
+//! A JSON serialization and deserialization module.
 use std::marker::PhantomData;
 
 use serde::{Deserialize, Serialize};
@@ -5,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use super::Error;
 use crate::serde::{Deserializer, Serializer};
 
-/// A JSON serialization and deserialization module.
+/// A struct to serialize and deserialize JSON payloads.
 #[derive(Debug, Clone, Copy)]
 pub struct Json<T>(PhantomData<T>);
 

--- a/disintegrate-serde/src/serde/prost.rs
+++ b/disintegrate-serde/src/serde/prost.rs
@@ -1,3 +1,6 @@
+//! A Protobuf serialization and deserialization module using Prost.
+//!
+//! This module provides the capability to serialize and deserialize data using the Prost library.
 use std::marker::PhantomData;
 
 use prost::{bytes::Bytes, Message};
@@ -5,9 +8,7 @@ use prost::{bytes::Bytes, Message};
 use super::Error;
 use crate::serde::{Deserializer, Serializer};
 
-/// A serialization and deserialization module using Prost.
-///
-/// This module provides the capability to serialize and deserialize data using the Prost library.
+/// A struct to serialize and deserialize Protobuf payloads.
 #[derive(Debug, Clone, Copy)]
 pub struct Prost<I, O>(PhantomData<I>, PhantomData<O>)
 where

--- a/disintegrate-serde/src/serde/protobuf.rs
+++ b/disintegrate-serde/src/serde/protobuf.rs
@@ -1,3 +1,4 @@
+//! A Protobuf serialization and deserialization module.
 use std::marker::PhantomData;
 
 use super::Error;
@@ -5,7 +6,7 @@ use protobuf::Message;
 
 use crate::serde::{Deserializer, Serializer};
 
-/// A serialization and deserialization module using Protobuf.
+/// A struct to serialize and deserialize Protobuf payloads.
 #[derive(Debug, Clone, Copy)]
 pub struct Protobuf<I, O>(PhantomData<I>, PhantomData<O>)
 where

--- a/disintegrate/Cargo.toml
+++ b/disintegrate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "disintegrate"
 description = "Disintegrate is a Rust library to build event-sourced applications."
-version = "0.5.0"
+version = "0.6.0"
 license.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -20,12 +20,13 @@ serde-protobuf = ["serde", "disintegrate-serde/protobuf"]
 async-trait = "0.1.74"
 futures = "0.3.29"
 lazy_static = "1.4.0"
-regex = "1.8.0"
+regex = "1.9.4"
 serde = { version = "1.0.190", features = ["derive"] }
-disintegrate-serde = { version = "0.2.0", path = "../disintegrate-serde", optional = true }
-disintegrate-macros = { version = "0.4.0", path = "../disintegrate-macros", optional = true }
+disintegrate-serde = { version = "0.2.1", path = "../disintegrate-serde", optional = true }
+disintegrate-macros = { version = "0.6.0", path = "../disintegrate-macros", optional = true }
 thiserror = "1.0.50"
 mockall = "0.11.4"
+paste = "1.0.14"
 
 [dev-dependencies]
-assert2 = "0.3.10"
+assert2 = "0.3.11"

--- a/disintegrate/src/decision.rs
+++ b/disintegrate/src/decision.rs
@@ -1,395 +1,185 @@
 //! A Decision serves as a building block for developing the business logic of an application.
 
-use crate::stream_query::StreamQuery;
-use crate::EventStore;
-use crate::{event::Event, PersistedEvent};
-use futures::TryStreamExt;
-use std::error::Error as StdError;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 
-/// Represents a business decision taken from the occurred events.
+use crate::stream_query::StreamQuery;
+use crate::BoxDynError;
+use crate::{event::Event, PersistedEvent};
+
+mod state;
+mod state_store;
+
+pub use state::{IntoState, IntoStatePart, MultiState, StateMutate, StatePart, StateQuery};
+pub use state_store::{
+    DecisionStateStore, EventSourcedDecisionStateStore, NoSnapshot, SnapshotConfig,
+    StateSnapshotter, WithSnapshot,
+};
+/// Represents a business decision taken from a state built upon the occurred events.
 pub trait Decision: Send + Sync {
     type Event: Event + Clone + Send + Sync;
-    type State: State + Clone + Send + Sync;
+    type StateQuery: Clone + Send + Sync;
     type Error: Send + Sync;
 
-    /// Returns the default state that will be mutated using the event store.
-    /// In case there are no events in the event store that match the query of the state,
-    /// this default state will be used to make the decision.
-    fn default_state(&self) -> Self::State;
+    /// Returns the state query to compute the decision state from the events in the event store.
+    ///
+    /// If there are no events that match the specified query, the default values of the state query is utilized to make the decision.
+    fn state_query(&self) -> Self::StateQuery;
 
-    /// Retrieves the stream query used to validate the decision.
-    /// If the validation query is `None`, the StreamQuery of the default state will be used for validation.
-    /// This means that the decision will only be confirmed if new events that would make the state outdated are not found.
+    /// Returns the stream query used to validate the decision.
+    ///
+    /// If the validation query is `None`, the state query will be used for validation.
+    /// This means that the decision will only be confirmed if new events that would make the state query outdated are not found.
     /// However, if a `validation_query` is provided, it will be used to confirm the decision.
     /// This allows narrowing down the set of events that could invalidate the decision.
     ///
     /// For example, in a banking system, deposit events should not invalidate withdrawals if the account balance is already sufficient.
-    /// In this case, the query of the state needs to include both withdraw and deposit events to compute the available balance,
+    /// In this case, the state query needs to include both withdraw and deposit events to compute the available balance,
     /// but only withdraw events should invalidate the decision.
     /// In other words, once we have confirmed that the account has a sufficient amount,
     /// only a withdraw event can reduce the balance below the requested amount and invalidate the decision.
-    fn validation_query(&self) -> Option<StreamQuery<<Self::State as State>::Event>>;
-
-    /// Process the decision from the mutated state.
-    fn process(&self, state: &Self::State) -> Result<Vec<Self::Event>, Self::Error>;
-}
-
-pub struct PersistedDecision<S: State, E: Event> {
-    state: S,
-    events: Vec<PersistedEvent<E>>,
-}
-
-impl<S: State, E: Event> PersistedDecision<S, E> {
-    /// Returns the state used to derive the decision
-    pub fn state(&self) -> &S {
-        &self.state
+    fn validation_query(&self) -> Option<StreamQuery<Self::Event>> {
+        None
     }
 
-    /// Returns the persisted events produced by the decision
-    pub fn events(&self) -> &[PersistedEvent<E>] {
-        &self.events
-    }
+    /// Evaluates the decision based on the mutated state, ensuring that all business rules
+    /// are verified against the current state. This method generates a series of events
+    /// that capture the changes made by the decision, allowing the results to be
+    /// persisted in the event store.
+    ///
+    /// # Parameters
+    ///
+    /// - `state`: A reference to the current state of the system, obtained through
+    ///   the implementation of the `StateQuery` trait.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` indicating the success of the process. If successful, it contains
+    /// a vector of events representing the changes made. In case of an error, it
+    /// contains details about the encountered issue.
+    fn process(&self, state: &Self::StateQuery) -> Result<Vec<Self::Event>, Self::Error>;
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum Error<ES, DE> {
+pub enum Error<DE> {
     #[error("event store error: {0}")]
-    EventStore(#[source] ES),
+    EventStore(#[source] BoxDynError),
+    #[error("state store error: {0}")]
+    StateStore(#[source] BoxDynError),
     #[error("domain error: {0}")]
     Domain(#[source] DE),
 }
 
-/// Executes business decisions.
+/// The `DecisionMaker` struct is responsible for executing and persisting business decisions.
 #[derive(Clone)]
-pub struct DecisionMaker<ES> {
-    event_store: ES,
+pub struct DecisionMaker<SS> {
+    state_store: SS,
 }
 
-impl<ES> DecisionMaker<ES> {
+impl<SS> DecisionMaker<SS> {
     /// Creates a new instance of `DecisionMaker`.
-    pub fn new<E>(event_store: ES) -> Self
-    where
-        E: Event + Clone + Sync + Send,
-        ES: EventStore<E>,
-    {
-        Self { event_store }
+    ///
+    /// # Parameters
+    ///
+    /// - `state_store`: The state store backend used by the `DecisionMaker` to load the current state
+    ///  and persist the decision.
+    pub fn new(state_store: SS) -> Self {
+        Self { state_store }
     }
 
-    /// Makes the given business decision.
+    /// Makes the given business decision, persisting the resulting events in the event store.
     ///
-    /// It then persists the resulting events in the event store
-    /// and returns the persisted events along with the hydrated state.
+    /// # Parameters
     ///
-    /// Note: the returned state is not mutated with the resulting decision events.
-    /// This is because a decision may produce a different set of events
-    /// compared to the events used by a State.
-    pub async fn make<D, S, E, DE, QE>(
+    /// - `decision`: The business decision to be executed, implementing the `Decision` trait.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` indicating the success of the decision-making process. If successful,
+    /// it contains a vector of `PersistedEvent` representing the changes made. In case of
+    /// an error, it contains details about the encountered issue.
+    pub async fn make<D, S, DS, E>(
         &self,
         decision: D,
-    ) -> Result<PersistedDecision<S, E>, Error<ES::Error, D::Error>>
+    ) -> Result<Vec<PersistedEvent<E>>, Error<D::Error>>
     where
-        E: Event + Clone + Sync + Send,
-        ES: EventStore<E>,
-        D: Decision<State = S, Event = DE>,
-        DE: Into<E> + Event,
-        S: State<Event = QE>,
-        QE: TryFrom<E> + Event + 'static + Clone + Send + Sync,
-        <QE as TryFrom<E>>::Error: StdError + 'static + Send + Sync,
-        <ES as EventStore<E>>::Error: 'static,
+        E: Event + Clone + Sync + Send + 'static,
+        SS: DecisionStateStore<DS, E>,
+        D: Decision<StateQuery = S, Event = E>,
+        S: Send + Sync + Serialize + DeserializeOwned + IntoStatePart<S, Target = DS>,
+        DS: Send + Sync + Serialize + DeserializeOwned + IntoState<S>,
         <D as Decision>::Error: 'static,
     {
-        let default_state = decision.default_state();
         let (state, version) = self
-            .event_store
-            .stream(&default_state.query())
-            .try_fold((default_state, 0), |(mut state, _), evt| async move {
-                let applied_event_id = evt.id();
-                state.mutate(evt.into_inner());
-                Ok((state, applied_event_id))
-            })
+            .state_store
+            .load(decision.state_query().into_state_part())
             .await
-            .map_err(Error::EventStore)?;
-        let changes = decision.process(&state).map_err(Error::Domain)?;
+            .map_err(Error::StateStore)?;
+        let inner_state = state.into_state();
+        let changes = decision.process(&inner_state).map_err(Error::Domain)?;
         let events = self
-            .event_store
-            .append(
-                changes.into_iter().map(|change| change.into()).collect(),
-                decision.validation_query().unwrap_or_else(|| state.query()),
+            .state_store
+            .persist(
+                inner_state.into_state_part(),
+                changes.into_iter().collect(),
+                decision.validation_query(),
                 version,
             )
             .await
-            .map_err(Error::EventStore)?;
+            .map_err(Error::StateStore)?;
 
-        Ok(PersistedDecision { state, events })
+        Ok(events)
     }
-}
-
-/// Defines the behavior of State objects.
-///
-/// A state object represents a business concept and is built from events.
-/// The associated `Event` type represents the events that
-/// can mutate the state.
-pub trait State: Clone + Send + Sync {
-    type Event: Event + Clone + Send + Sync;
-
-    /// Returns the stream query used to retrieve relevant events for building the state.
-    fn query(&self) -> StreamQuery<Self::Event>;
-
-    /// Mutates the state object based on the provided event.
-    fn mutate(&mut self, event: Self::Event);
 }
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
 
-    use async_trait::async_trait;
-    use futures::{
-        executor::block_on,
-        stream::{self, BoxStream},
-        StreamExt,
-    };
-    use mockall::{automock, mock};
-    use serde::{Deserialize, Serialize};
+    use futures::executor::block_on;
+    use mockall::predicate::eq;
 
     use super::*;
-    use crate::{domain_identifiers, query, DomainIdentifierSet, EventSchema};
-
-    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-    #[serde(tag = "event_type", rename_all = "snake_case")]
-    enum ShoppingCartEvent {
-        ItemAdded {
-            item_id: String,
-            cart_id: String,
-            quantity: u32,
-        },
-        ItemUpdated {
-            item_id: String,
-            cart_id: String,
-            quantity: u32,
-        },
-        ItemRemoved {
-            item_id: String,
-            cart_id: String,
-            quantity: u32,
-        },
-    }
-
-    impl Event for ShoppingCartEvent {
-        const SCHEMA: EventSchema = EventSchema {
-            types: &["ItemAdded", "ItemUpdated", "ItemRemoved"],
-            domain_identifiers: &["cart_id", "product_id"],
-        };
-        fn name(&self) -> &'static str {
-            match self {
-                ShoppingCartEvent::ItemAdded { .. } => "ItemAdded",
-                ShoppingCartEvent::ItemUpdated { .. } => "ItemUpdated",
-                ShoppingCartEvent::ItemRemoved { .. } => "ItemRemoved",
-            }
-        }
-        fn domain_identifiers(&self) -> DomainIdentifierSet {
-            match self {
-                ShoppingCartEvent::ItemAdded {
-                    item_id, cart_id, ..
-                } => domain_identifiers! {item_id: item_id, cart_id: cart_id},
-                ShoppingCartEvent::ItemUpdated {
-                    item_id, cart_id, ..
-                } => domain_identifiers! {item_id: item_id, cart_id: cart_id},
-                ShoppingCartEvent::ItemRemoved {
-                    item_id, cart_id, ..
-                } => domain_identifiers! {item_id: item_id, cart_id: cart_id},
-            }
-        }
-    }
-
-    struct DummyEventStore<D> {
-        database: D,
-    }
-
-    #[derive(Debug)]
-    struct Error;
-
-    #[automock]
-    trait Database {
-        fn stream<QE: Event + Clone + 'static + Send + Sync>(
-            &self,
-            query: &StreamQuery<QE>,
-        ) -> Vec<Result<PersistedEvent<QE>, Error>>;
-
-        fn append<QE: Event + Clone + 'static + Send + Sync>(
-            &self,
-            events: Vec<ShoppingCartEvent>,
-            query: StreamQuery<QE>,
-            last_event_id: i64,
-        ) -> Vec<PersistedEvent<ShoppingCartEvent>>;
-    }
-
-    #[async_trait]
-    impl<D: Database + Sync> EventStore<ShoppingCartEvent> for DummyEventStore<D> {
-        type Error = Error;
-
-        fn stream<'a, QE>(
-            &'a self,
-            query: &'a StreamQuery<QE>,
-        ) -> BoxStream<Result<PersistedEvent<QE>, Self::Error>>
-        where
-            QE: TryFrom<ShoppingCartEvent> + Event + 'static + Clone + Send + Sync,
-            <QE as TryFrom<ShoppingCartEvent>>::Error: StdError + 'static + Send + Sync,
-        {
-            stream::iter(self.database.stream(query)).boxed()
-        }
-
-        async fn append<QE>(
-            &self,
-            events: Vec<ShoppingCartEvent>,
-            query: StreamQuery<QE>,
-            last_event_id: i64,
-        ) -> Result<Vec<PersistedEvent<ShoppingCartEvent>>, Self::Error>
-        where
-            QE: Event + 'static + Clone + Send + Sync,
-        {
-            Ok(self.database.append(events, query, last_event_id))
-        }
-    }
-
-    #[derive(Default, Debug, Clone, Eq, PartialEq)]
-    struct Cart {
-        cart_id: String,
-        items: HashMap<String, u32>,
-    }
-
-    impl Cart {
-        pub fn new(cart_id: &str) -> Self {
-            Self {
-                cart_id: cart_id.into(),
-                ..Default::default()
-            }
-        }
-    }
-
-    impl State for Cart {
-        type Event = ShoppingCartEvent;
-
-        fn query(&self) -> StreamQuery<Self::Event> {
-            query!(ShoppingCartEvent, cart_id == self.cart_id)
-        }
-
-        fn mutate(&mut self, event: Self::Event) {
-            match event {
-                ShoppingCartEvent::ItemAdded {
-                    item_id, quantity, ..
-                } => {
-                    self.items.insert(item_id, quantity);
-                }
-                ShoppingCartEvent::ItemRemoved { item_id, .. } => {
-                    self.items.remove(&item_id);
-                }
-                ShoppingCartEvent::ItemUpdated {
-                    item_id, quantity, ..
-                } => {
-                    self.items.insert(item_id, quantity);
-                }
-            }
-        }
-    }
-
-    #[derive(Debug)]
-    enum CartError {}
-
-    mock! {
-            AddItem{}
-            impl Decision for AddItem {
-                type Event = ShoppingCartEvent;
-                type State = Cart;
-                type Error = CartError;
-
-            fn default_state(&self) -> <Self as Decision>::State;
-            fn validation_query(&self) -> Option<StreamQuery<ShoppingCartEvent>>;
-            fn process(&self, _state: &<Self as Decision>::State) -> Result<Vec<<Self as Decision>::Event>, <Self as Decision>::Error>;
-        }
-    }
+    use crate::{utils::tests::*, EventSourcedDecisionStateStore, NoSnapshot, StateQuery};
 
     #[test]
-    fn it_should_hydrate_state_and_persist_event() {
-        let mut mock_database = MockDatabase::new();
+    fn it_processes_a_decision() {
+        let mut database = MockDatabase::new();
 
-        mock_database.expect_stream().once().return_once(|_| {
-            vec![
-                Ok(PersistedEvent::new(
-                    1,
-                    ShoppingCartEvent::ItemAdded {
-                        item_id: "p1".to_owned(),
-                        cart_id: "c1".to_owned(),
-                        quantity: 2,
-                    },
-                )),
-                Ok(PersistedEvent::new(
-                    2,
-                    ShoppingCartEvent::ItemAdded {
-                        item_id: "p2".to_owned(),
-                        cart_id: "c1".to_owned(),
-                        quantity: 3,
-                    },
-                )),
-            ]
+        database.expect_stream().once().return_once(|_| {
+            event_stream([item_added_event("p1", "c1"), item_removed_event("p1", "c1")])
         });
 
-        mock_database.expect_append().once().return_once(
-            |_, _: StreamQuery<ShoppingCartEvent>, _| {
-                vec![PersistedEvent::new(
-                    3,
-                    ShoppingCartEvent::ItemAdded {
-                        item_id: "p3".to_owned(),
-                        cart_id: "c1".to_owned(),
-                        quantity: 1,
-                    },
-                )]
-            },
-        );
-
-        let mut mock_add_item = MockAddItem::new();
-        mock_add_item
-            .expect_default_state()
+        let state_query = cart("c1", []).query().change_origin(0);
+        database
+            .expect_append()
+            .with(
+                eq(vec![item_added_event("p2", "c1")]),
+                eq(state_query),
+                eq(2),
+            )
             .once()
-            .return_once(|| Cart::new("c1"));
+            .return_once(|_, _: StreamQuery<ShoppingCartEvent>, _| {
+                vec![PersistedEvent::new(3, item_added_event("p2", "c1"))]
+            });
+
+        let mut mock_add_item = MockDecision::new();
+        mock_add_item
+            .expect_state_query()
+            .once()
+            .return_once(|| cart("c1", []));
         mock_add_item
             .expect_validation_query()
             .once()
             .return_once(|| None);
-        mock_add_item.expect_process().once().return_once(|_| {
-            Ok(vec![ShoppingCartEvent::ItemAdded {
-                cart_id: "c1".to_string(),
-                item_id: "p3".to_string(),
-                quantity: 1,
-            }])
-        });
+        mock_add_item
+            .expect_process()
+            .once()
+            .return_once(|_| Ok(vec![item_added_event("p2", "c1")]));
 
-        let event_store = DummyEventStore {
-            database: mock_database,
-        };
+        let event_store = MockEventStore::new(database);
+        let state_store = EventSourcedDecisionStateStore::new(event_store, NoSnapshot);
+        let decision_maker = DecisionMaker::new(state_store);
 
-        let decision_maker = DecisionMaker::new(event_store);
-
-        let result = block_on(decision_maker.make(mock_add_item));
-
-        let persisted_decision = result.unwrap();
-
-        let expected_cart_state = Cart {
-            cart_id: "c1".to_owned(),
-            items: vec![("p1".to_owned(), 2), ("p2".to_owned(), 3)]
-                .into_iter()
-                .collect(),
-        };
-        assert_eq!(persisted_decision.state(), &expected_cart_state);
-
-        let persisted_events = persisted_decision.events();
-        assert_eq!(
-            *persisted_events[0],
-            ShoppingCartEvent::ItemAdded {
-                item_id: "p3".to_owned(),
-                cart_id: "c1".to_owned(),
-                quantity: 1,
-            }
-        );
+        block_on(decision_maker.make(mock_add_item)).unwrap();
     }
 }

--- a/disintegrate/src/decision/state.rs
+++ b/disintegrate/src/decision/state.rs
@@ -1,0 +1,430 @@
+//! A State contains the initial conditions that a `Decision` uses to make the changes.
+use serde::Deserialize;
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::stream_query::{StreamFilter, StreamQuery};
+use crate::{all_the_tuples, union, BoxDynError, StateSnapshotter};
+use crate::{event::Event, PersistedEvent};
+use async_trait::async_trait;
+use paste::paste;
+use std::error::Error as StdError;
+use std::ops::Deref;
+
+/// A mutable state that can be changed by events from the event store.
+pub trait StateMutate: StateQuery {
+    /// Mutates the state object based on the provided event.
+    ///
+    /// # Arguments
+    ///
+    /// * `event` - The event to be applied to mutate the state.
+    fn mutate(&mut self, event: Self::Event);
+}
+
+/// A group of states that can be queried and modified together.
+///
+/// The states can be mutated collectively based on an event
+/// retrieved from the event store, and a unified query can be generated for all sub-states.
+///
+/// # Type Parameters
+///
+/// - `E`: The type of events that the multi-state object handles.
+pub trait MultiState<E: Event + Clone> {
+    /// Mutates all sub-states based on the provided event.
+    ///
+    /// # Arguments
+    ///
+    /// * `event` - The event to be applied to mutate the sub-states.
+    fn mutate_all(&mut self, event: PersistedEvent<E>);
+    /// The unified query that represents the union of queries for all sub-states.
+    ///
+    /// This query can be used to retrieve a stream of events relevant to the entire multi-state
+    /// object.
+    ///
+    /// # Returns
+    ///
+    /// A `StreamQuery` representing the combined query for all sub-states.
+    fn query_all(&self) -> StreamQuery<E>;
+
+    /// Returns the version of the multi-state.
+    ///
+    /// The multi-state version is determined as the maximum of the versions
+    /// of its sub-states.
+    ///
+    /// # Returns
+    ///
+    /// The method returns an `i64` representing the version of the multi-state.
+    fn version(&self) -> i64;
+}
+
+macro_rules! impl_multi_state {
+    (
+        [$($ty:ident),*], $last:ident
+    ) => {
+        #[allow(unused_parens)]
+        impl<E, $($ty,)* $last> MultiState<E> for ($(StatePart<$ty>,)* StatePart<$last>)
+        where
+            E: Event + Clone,
+            $($ty: StateQuery + StateMutate,)*
+            $last: StateQuery + StateMutate,
+            <$last as StateQuery>::Event: TryFrom<E> + Into<E>,
+            $(<$ty as StateQuery>::Event: TryFrom<E> + Into<E>,)*
+            <$last as StateQuery>::Event: TryFrom<E> + Into<E>,
+            $(<<$ty as StateQuery>::Event as TryFrom<E>>::Error:
+                StdError + 'static + Send + Sync,)*
+            <<$last as StateQuery>::Event as TryFrom<E>>::Error:
+                StdError + 'static + Send + Sync,
+        {
+            fn mutate_all(&mut self, event: PersistedEvent<E>) {
+                paste! {
+                    let ($([<state_ $ty:lower>],)* [<state_ $last:lower>])= self;
+                    $(
+                        if [<state_ $ty:lower>].matches_event(&event) {
+                            [<state_ $ty:lower>].mutate_part(event.clone());
+                        }
+                    )*
+                    if [<state_ $last:lower>].matches_event(&event) {
+                         [<state_ $last:lower>].mutate_part(event.clone());
+                    }
+                }
+            }
+
+            fn query_all(&self) -> StreamQuery<E> {
+                paste!{
+                    let ($([<state_ $ty:lower>],)* [<state_ $last:lower>])= self;
+                    union!($([<state_ $ty:lower>].query_part(),)* [<state_ $last:lower>].query_part())
+                }
+            }
+            fn version(&self) -> i64 {
+                paste!{
+                    let ($([<state_ $ty:lower>],)* [<state_ $last:lower>])= self;
+                    let version = [<state_ $last:lower>].version();
+                    $(
+                        let version = version.max([<state_ $ty:lower>].version());
+                    )*
+                    version
+                }
+            }
+        }
+    }
+}
+
+all_the_tuples!(impl_multi_state);
+
+/// A multi-state snapshot.
+///
+/// A trait necessary to handle the snapshot of its sub-states' load and store.
+///
+/// # Type Parameters
+///
+/// - `T`: The type of snapshotter used for loading and storing snapshots.
+/// - `E`: The type of events that the multi-state object handles.
+#[async_trait]
+pub trait MultiStateSnapshot<T: StateSnapshotter> {
+    // Loads the state of all sub-states using the provided snapshotter
+    /// and returns the version of the multi-state object.
+    ///
+    /// # Arguments
+    ///
+    /// * `backend` - The snapshotter used to load the state of sub-states.
+    ///
+    /// # Returns
+    ///
+    /// Returns the version of the multi-state object after loading its state.
+    async fn load_all(&mut self, backend: &T) -> i64;
+    /// Stores the snapshot of all sub-states using the provided snapshotter.
+    ///
+    /// # Arguments
+    ///
+    /// * `backend` - The snapshotter used to store the snapshot of sub-states.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` indicating the success or failure of the storage operation.
+    async fn store_all(&self, backend: &T) -> Result<(), BoxDynError>;
+}
+
+macro_rules! impl_multi_state_snapshot {
+    (
+        [$($ty:ident),*], $last:ident
+    ) => {
+        #[async_trait]
+        #[allow(unused_parens)]
+        impl<B, $($ty,)* $last> MultiStateSnapshot<B> for ($(StatePart<$ty>,)* StatePart<$last>)
+        where
+            B: StateSnapshotter + Send + Sync,
+            $($ty: StateQuery + Serialize + DeserializeOwned + 'static,)*
+            $last: StateQuery + Serialize + DeserializeOwned + 'static,
+        {
+            async fn load_all(&mut self, backend: &B) -> i64 {
+                paste! {
+
+                    let ($([<state_ $ty:lower>],)* [<state_ $last:lower>]) = self;
+                    *[<state_ $last:lower>] = backend.load_snapshot([<state_ $last:lower>].clone()).await;
+                    let last_event_id = [<state_ $last:lower>].version;
+                    $(
+                        *[<state_ $ty:lower>] = backend.load_snapshot([<state_ $ty:lower>].clone()).await;
+                        let last_event_id = last_event_id.max([<state_ $ty:lower>].version);
+                    )*
+                }
+                last_event_id
+            }
+
+            async fn store_all(&self, backend: &B) -> Result<(), BoxDynError>{
+                paste!{
+
+                    let ($([<state_ $ty:lower>],)* [<state_ $last:lower>]) = self;
+                    $(
+                    backend.store_snapshot(&[<state_ $ty:lower>]).await?;
+                    )*
+                    backend.store_snapshot(&[<state_ $last:lower>]).await?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+all_the_tuples!(impl_multi_state_snapshot);
+
+/// Represents a state query used to retrieve events from the event store to build a state.
+///
+/// The query method returns a `StreamQuery` to be used for querying the event store.
+pub trait StateQuery: Clone + Send + Sync {
+    /// the unique name of the state query.
+    const NAME: &'static str;
+    /// The type of events queried by this state query.
+    type Event: Event + Clone + Send + Sync;
+
+    /// Returns the stream query used to retrieve relevant events for building the state.
+    fn query(&self) -> StreamQuery<Self::Event>;
+}
+
+impl<S, E: Clone> From<&S> for StreamQuery<E>
+where
+    S: StateQuery<Event = E>,
+{
+    fn from(state: &S) -> Self {
+        state.query()
+    }
+}
+
+/// A structure representing a sub-state in a multi-state object. It encapsulates
+/// the version, applied events count, and the payload of a sub-state.
+///
+/// # Type Parameters
+///
+/// - `S`: The type implementing the `StateMutate` trait, representing the sub-state.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct StatePart<S: StateQuery> {
+    /// The version of the sub-state.
+    version: i64,
+    /// The count of events applied to the sub-state.
+    applied_events: u64,
+    /// The payload of the sub-state.
+    inner: S,
+}
+
+impl<S: StateQuery> StatePart<S> {
+    pub fn new(version: i64, payload: S) -> Self {
+        Self {
+            version,
+            applied_events: 0,
+            inner: payload,
+        }
+    }
+    pub fn version(&self) -> i64 {
+        self.version
+    }
+    pub fn applied_events(&self) -> u64 {
+        self.applied_events
+    }
+    pub fn query_part(&self) -> StreamQuery<<S as StateQuery>::Event> {
+        self.inner.query().change_origin(self.version)
+    }
+
+    pub fn matches_event<U>(&self, event: &PersistedEvent<U>) -> bool
+    where
+        U: Event + Clone,
+        <S as StateQuery>::Event: Into<U>,
+    {
+        matches_filter(event, self.query_part().convert().filter())
+    }
+    pub fn mutate_part<E>(&mut self, event: PersistedEvent<E>)
+    where
+        E: Event,
+        S: StateMutate,
+        <S as StateQuery>::Event: TryFrom<E>,
+        <<S as StateQuery>::Event as TryFrom<E>>::Error: StdError + 'static + Send + Sync,
+    {
+        self.version = event.id;
+        self.applied_events += 1;
+        self.inner.mutate(event.event.try_into().unwrap());
+    }
+}
+
+impl<S: StateQuery> Deref for StatePart<S> {
+    type Target = S;
+
+    fn deref(&self) -> &S {
+        &self.inner
+    }
+}
+
+/// Converts an state into `StatePart`s.
+///
+/// This trait is used to initialize a multi-state object by converting a state into a state part
+/// with version and event information.
+///
+/// # Type Parameters
+///
+/// - `T`: The type of the object that can be converted into a `StatePart`.
+///
+/// # Associated Types
+///
+/// - `Target`: The resulting type after conversion, representing a `StatePart`.
+pub trait IntoStatePart<T>: Sized {
+    type Target;
+    /// Converts the object into a `StatePart`.
+    ///
+    /// # Returns
+    ///
+    /// Returns the resulting `StatePart` after the conversion.
+    fn into_state_part(self) -> Self::Target;
+}
+
+/// Extracts the state payload from a `StatePart`.
+///
+/// # Type Parameters
+///
+/// - `T`: The type representing the concrete state to be obtained from the `StatePart`.
+pub trait IntoState<T>: Sized {
+    /// Converts the `StatePart` into a concrete state type.
+    ///
+    /// # Returns
+    ///
+    /// Returns the concrete state obtained from the `StatePart`.
+    fn into_state(self) -> T;
+}
+
+fn matches_filter<E: Event>(event: &PersistedEvent<E>, filter: &StreamFilter) -> bool {
+    match filter {
+        StreamFilter::Events { names } => names.contains(&event.name()),
+        StreamFilter::ExcludeEvents { names } => !names.contains(&event.name()),
+        StreamFilter::Eq { ident, value } => event
+            .domain_identifiers()
+            .get(ident)
+            .map(|v| v == value)
+            .unwrap_or_default(),
+        StreamFilter::And { l, r } => matches_filter(event, l) && matches_filter(event, r),
+        StreamFilter::Or { l, r } => matches_filter(event, l) || matches_filter(event, r),
+        StreamFilter::Origin { id } => event.id() > *id,
+    }
+}
+
+macro_rules! impl_from_state {
+    (
+        [$($ty:ident),*], $last:ident
+    ) => {
+        #[allow(unused_parens)]
+        impl<$($ty,)* $last> IntoStatePart<($($ty,)* $last)> for ($($ty,)* $last) where
+            $($ty: StateQuery,)*
+            $last: StateQuery,
+        {
+            type Target = ($(StatePart<$ty>,)* StatePart<$last>);
+            paste::paste! {
+                fn into_state_part(self) -> ($(StatePart<$ty>,)*StatePart<$last>){
+                    let ($([<state_ $ty:lower>],)* [<state_ $last:lower>])= self;
+                    ($(StatePart{ inner: [<state_ $ty:lower>], version: 0, applied_events: 0},)* StatePart{inner: [<state_ $last:lower>], version: 0, applied_events: 0})
+                }
+            }
+        }
+
+        #[allow(unused_parens)]
+        impl<$($ty,)* $last> IntoState<($($ty,)* $last)> for ($(StatePart<$ty>,)* StatePart<$last>) where
+            $($ty: StateQuery,)*
+            $last: StateQuery,
+        {
+            paste::paste! {
+                fn into_state(self) -> ($($ty,)* $last){
+                    let ($([<state_ $ty:lower>],)* [<state_ $last:lower>])= self;
+                    ($( [<state_ $ty:lower>].inner,)* [<state_ $last:lower>].inner)
+                }
+            }
+        }
+    }
+}
+
+all_the_tuples!(impl_from_state);
+
+#[cfg(test)]
+mod test {
+    use futures::executor::block_on;
+
+    use super::*;
+    use crate::utils::tests::*;
+
+    #[test]
+    fn it_mutates_all() {
+        let mut state = (Cart::new("c1"), Cart::new("c2")).into_state_part();
+        state.mutate_all(PersistedEvent::new(1, item_added_event("p1", "c1")));
+        state.mutate_all(PersistedEvent::new(2, item_added_event("p2", "c2")));
+        let (cart1, cart2) = state;
+        assert_eq!(cart1.version, 1);
+        assert_eq!(cart1.applied_events, 1);
+        assert_eq!(cart1.into_state(), cart("c1", ["p1".to_string()]));
+        assert_eq!(cart2.version, 2);
+        assert_eq!(cart2.applied_events, 1);
+        assert_eq!(cart2.into_state(), cart("c2", ["p2".to_string()]));
+    }
+
+    #[test]
+    fn it_queries_all() {
+        let cart1 = Cart::new("c1");
+        let cart2 = Cart::new("c2");
+        let state = (cart1.clone(), cart2.clone()).into_state_part();
+        let query: StreamQuery<ShoppingCartEvent> = state.query_all();
+        assert_eq!(
+            query,
+            union!(
+                cart1.query().change_origin(0),
+                cart2.query().change_origin(0)
+            )
+        );
+    }
+
+    #[test]
+    fn it_stores_all() {
+        let multi_state = (cart("c1", []), cart("c2", [])).into_state_part();
+        let mut snapshotter = MockStateSnapshotter::new();
+        snapshotter
+            .expect_store_snapshot()
+            .once()
+            .withf(|s: &StatePart<Cart>| s.inner == cart("c1", []))
+            .return_once(|_| Ok(()));
+        snapshotter
+            .expect_store_snapshot()
+            .once()
+            .withf(|s: &StatePart<Cart>| s.inner == cart("c2", []))
+            .return_once(|_| Ok(()));
+        block_on(multi_state.store_all(&snapshotter)).unwrap();
+    }
+
+    #[test]
+    fn it_loads_all() {
+        let mut multi_state = (cart("c1", []), cart("c2", [])).into_state_part();
+        let mut snapshotter = MockStateSnapshotter::new();
+        snapshotter
+            .expect_load_snapshot()
+            .once()
+            .withf(|q| q.inner == cart("c1", []))
+            .returning(|_| cart("c1", ["p1".to_owned()]).into_state_part());
+        snapshotter
+            .expect_load_snapshot()
+            .once()
+            .withf(|q| q.inner == cart("c2", []))
+            .returning(|_| cart("c2", ["p2".to_owned()]).into_state_part());
+        block_on(multi_state.load_all(&snapshotter));
+        let (cart1, cart2) = multi_state;
+        assert_eq!(cart1.inner, cart("c1", ["p1".to_owned()]));
+        assert_eq!(cart2.inner, cart("c2", ["p2".to_owned()]));
+    }
+}

--- a/disintegrate/src/decision/state_store.rs
+++ b/disintegrate/src/decision/state_store.rs
@@ -1,0 +1,343 @@
+//! State Store provides components for retrieving decision states and persisting decision changes.
+use serde::{de::DeserializeOwned, Serialize};
+
+use super::state::{MultiState, MultiStateSnapshot, StatePart};
+use crate::BoxDynError;
+use crate::EventStore;
+use crate::StateQuery;
+use crate::{Event, PersistedEvent, StreamQuery};
+use async_trait::async_trait;
+use futures::TryStreamExt;
+use std::error::Error as StdError;
+use std::ops::Deref;
+
+/// A decision state store.
+///
+/// It provides methods for loading decision states and persisting decision changes.
+#[async_trait]
+pub trait DecisionStateStore<S, E: Event + Clone> {
+    /// Loads the decision state based on the provided state query.
+    ///
+    /// This method retrieves the current state from the storage backend, along with
+    /// its version.
+    ///
+    /// # Parameters
+    ///
+    /// - `state_query`: The query object representing the desired state to hydrate.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing a tuple with the loaded state and its version, or an
+    /// error if the load fails.
+    async fn load(&self, state_query: S) -> Result<(S, i64), BoxDynError>;
+    /// Persists the decision changes.
+    ///
+    /// # Parameters
+    ///
+    /// - `query_state`: The query state used to load the decision state.
+    /// - `events`: A vector of events representing the changes to be stored.
+    /// - `validation_query`: An optional stream query to perform validation of the state.
+    /// - `state_version`: The version of the used by the decision. It is the version returned by the `load` method.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing a vector of `PersistedEvent` or an error if the persist fails.
+    async fn persist(
+        &self,
+        query_state: S,
+        events: Vec<E>,
+        validation_query: Option<StreamQuery<E>>,
+        state_version: i64,
+    ) -> Result<Vec<PersistedEvent<E>>, BoxDynError>;
+}
+
+/// A snapshotter.
+///
+/// Snapshots optimize the retrieval of `StatePart` by storing and loading partial or complete
+/// representations of previously computed states.
+///
+/// Snapshots serve as a mechanism to enhance performance, enabling quicker access to cached states
+/// and reducing the need for redundant recalculations of identical state queries.
+#[async_trait]
+pub trait StateSnapshotter {
+    /// Loads a snapshot of a state part. If the snapshot is not present of invalid, it returns the provided `default`.
+    ///
+    /// - `default`: The default state to be used if no snapshot is available.
+    ///
+    /// Returns the loaded or default `StatePart<S>`.
+    async fn load_snapshot<S>(&self, default: StatePart<S>) -> StatePart<S>
+    where
+        S: Send + Sync + DeserializeOwned + StateQuery + 'static;
+
+    /// Stores a snapshot of the provided state part.
+    ///
+    /// - `state`: The state to be stored as a snapshot.
+    ///
+    /// Returns a `Result` indicating the success or failure of the operation.
+    async fn store_snapshot<S>(&self, state: &StatePart<S>) -> Result<(), BoxDynError>
+    where
+        S: Send + Sync + Serialize + StateQuery + 'static;
+}
+
+/// Snapshot configuration indicating how the snapshot of a `StatePart` must be performed.
+pub trait SnapshotConfig {}
+
+/// Indicates that the snapshot is disabled.
+#[derive(Clone, Copy)]
+pub struct NoSnapshot;
+
+impl SnapshotConfig for NoSnapshot {}
+
+/// Indicates that the snapshot is enabled and handled by the provided backend.
+#[derive(Clone, Copy)]
+pub struct WithSnapshot<T: StateSnapshotter + Clone> {
+    backend: T,
+}
+impl<T: StateSnapshotter + Clone> WithSnapshot<T> {
+    pub fn new(backend: T) -> Self {
+        WithSnapshot { backend }
+    }
+}
+
+impl<T: StateSnapshotter + Clone> SnapshotConfig for WithSnapshot<T> {}
+
+impl<T: StateSnapshotter + Clone> Deref for WithSnapshot<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.backend
+    }
+}
+
+/// Represents an event sourced decision state store. It loads and stores decision states from events in a event store.
+#[derive(Clone)]
+pub struct EventSourcedDecisionStateStore<ES: Clone, SN: SnapshotConfig + Clone> {
+    event_store: ES,
+    snapshot: SN,
+}
+
+impl<ES: Clone, SN: SnapshotConfig + Clone> EventSourcedDecisionStateStore<ES, SN> {
+    pub fn new(event_store: ES, snapshot: SN) -> EventSourcedDecisionStateStore<ES, SN> {
+        EventSourcedDecisionStateStore {
+            event_store,
+            snapshot,
+        }
+    }
+}
+
+#[async_trait]
+impl<ES, E, S> DecisionStateStore<S, E> for EventSourcedDecisionStateStore<ES, NoSnapshot>
+where
+    ES: EventStore<E> + Clone + Sync + Send,
+    <ES as EventStore<E>>::Error: StdError + Send + Sync + 'static,
+    E: Event + Clone + Send + Sync + 'static,
+    S: MultiState<E> + Send + Sync + 'static,
+{
+    async fn load(&self, state_query: S) -> Result<(S, i64), BoxDynError> {
+        let initial_version = state_query.version();
+        let (state, version) = self
+            .event_store
+            .stream(&state_query.query_all())
+            .try_fold(
+                (state_query, initial_version),
+                |(mut state, version), evt| async move {
+                    let applied_event_id = evt.id();
+                    state.mutate_all(evt);
+                    Ok((state, version.max(applied_event_id)))
+                },
+            )
+            .await?;
+        Ok((state, version))
+    }
+
+    async fn persist(
+        &self,
+        state_query: S,
+        events: Vec<E>,
+        validation_query: Option<StreamQuery<E>>,
+        last_event_id: i64,
+    ) -> Result<Vec<PersistedEvent<E>>, BoxDynError> {
+        let query = validation_query.unwrap_or_else(|| state_query.query_all());
+        Ok(self
+            .event_store
+            .append(events, query, last_event_id)
+            .await?)
+    }
+}
+
+#[async_trait]
+impl<ES, E, S, B> DecisionStateStore<S, E> for EventSourcedDecisionStateStore<ES, WithSnapshot<B>>
+where
+    B: StateSnapshotter + Send + Sync + Clone,
+    ES: EventStore<E> + Clone + Sync + Send,
+    <ES as EventStore<E>>::Error: StdError + Send + Sync + 'static,
+    E: Event + Clone + Send + Sync + 'static,
+    S: MultiState<E> + MultiStateSnapshot<B> + Send + Sync + 'static,
+{
+    async fn load(&self, mut state_query: S) -> Result<(S, i64), BoxDynError> {
+        let version = state_query.load_all(&self.snapshot.backend).await;
+        let (state, version) = self
+            .event_store
+            .stream(&state_query.query_all())
+            .try_fold(
+                (state_query, version),
+                |(mut state, version), evt| async move {
+                    let applied_event_id = evt.id();
+                    state.mutate_all(evt);
+                    Ok((state, version.max(applied_event_id)))
+                },
+            )
+            .await?;
+        state.store_all(&self.snapshot.backend).await?;
+        Ok((state, version))
+    }
+
+    async fn persist(
+        &self,
+        from_state: S,
+        events: Vec<E>,
+        validation_query: Option<StreamQuery<E>>,
+        last_event_id: i64,
+    ) -> Result<Vec<PersistedEvent<E>>, BoxDynError> {
+        let query = validation_query.unwrap_or_else(|| from_state.query_all());
+        Ok(self
+            .event_store
+            .append(events, query, last_event_id)
+            .await?)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use futures::executor::block_on;
+
+    use super::*;
+    use crate::{utils::tests::*, IntoState, IntoStatePart};
+
+    #[test]
+    fn it_loads_query_state() {
+        let mut mock_store = MockDatabase::new();
+
+        mock_store.expect_stream().once().return_once(|_| {
+            event_stream([
+                item_added_event("p1", "c1"),
+                item_removed_event("p1", "c1"),
+                item_added_event("p3", "c2"),
+            ])
+        });
+
+        let event_store = MockEventStore::new(mock_store);
+        let state_store = EventSourcedDecisionStateStore::new(event_store, NoSnapshot);
+        let state = (cart("c1", []), cart("c2", [])).into_state_part();
+        let ((cart1, cart2), version) = block_on(state_store.load(state)).unwrap();
+
+        assert_eq!(version, 3);
+        assert_eq!(cart1.version(), 2);
+        assert_eq!(cart1.applied_events(), 2);
+        assert_eq!(cart1.into_state(), cart("c1", []));
+        assert_eq!(cart2.version(), 3);
+        assert_eq!(cart2.applied_events(), 1);
+        assert_eq!(cart2.into_state(), cart("c2", ["p3".to_owned()]));
+    }
+
+    #[test]
+    fn it_persists_decision_changes() {
+        let mut mock_store = MockDatabase::new();
+
+        mock_store
+            .expect_append()
+            .once()
+            .return_once(|_, _: StreamQuery<ShoppingCartEvent>, _| {
+                vec![PersistedEvent::new(1, item_added_event("p2", "c1"))]
+            });
+
+        let event_store = MockEventStore::new(mock_store);
+        let state_store = EventSourcedDecisionStateStore::new(event_store, NoSnapshot);
+        let state = (Cart::new("c1"), Cart::new("c2")).into_state_part();
+        block_on(state_store.persist(state, vec![item_added_event("p2", "c1")], None, 1)).unwrap();
+    }
+
+    #[test]
+    fn it_loads_query_state_from_snapshot() {
+        let mut mock_store = MockDatabase::new();
+
+        mock_store.expect_stream().once().return_once(|_| {
+            event_stream([item_added_event("p3", "c1"), item_added_event("p4", "c2")])
+        });
+
+        let mut snapshotter = MockStateSnapshotter::new();
+        snapshotter
+            .expect_load_snapshot()
+            .once()
+            .withf(|q: &StatePart<Cart>| q.cart_id == "c1")
+            .returning(|_| cart("c1", ["p1".to_owned()]).into_state_part());
+        snapshotter
+            .expect_load_snapshot()
+            .once()
+            .withf(|q: &StatePart<Cart>| q.cart_id == "c2")
+            .returning(|_| cart("c2", ["p2".to_owned()]).into_state_part());
+        snapshotter
+            .expect_store_snapshot()
+            .once()
+            .withf(|q: &StatePart<Cart>| q.cart_id == "c1")
+            .returning(|_| Ok(()));
+        snapshotter
+            .expect_store_snapshot()
+            .once()
+            .withf(|q: &StatePart<Cart>| q.cart_id == "c2")
+            .returning(|_| Ok(()));
+
+        let event_store = MockEventStore::new(mock_store);
+        let state_store =
+            EventSourcedDecisionStateStore::new(event_store, WithSnapshot::new(snapshotter));
+        let state = (cart("c1", []), cart("c2", [])).into_state_part();
+        let ((cart1, cart2), version) = block_on(state_store.load(state)).unwrap();
+
+        assert_eq!(version, 2);
+        assert_eq!(cart1.version(), 1);
+        assert_eq!(cart1.applied_events(), 1);
+        assert_eq!(
+            cart1.into_state(),
+            cart("c1", ["p1".to_owned(), "p3".to_owned()])
+        );
+        assert_eq!(cart2.version(), 2);
+        assert_eq!(cart2.applied_events(), 1);
+        assert_eq!(
+            cart2.into_state(),
+            cart("c2", ["p2".to_owned(), "p4".to_owned()])
+        );
+    }
+
+    #[test]
+    fn it_returns_the_max_version_of_the_loaded_snapshots() {
+        let mut mock_store = MockDatabase::new();
+
+        mock_store
+            .expect_stream()
+            .once()
+            .return_once(|_: &StreamQuery<ShoppingCartEvent>| event_stream([]));
+
+        let mut snapshotter = MockStateSnapshotter::new();
+        snapshotter
+            .expect_load_snapshot()
+            .once()
+            .withf(|q: &StatePart<Cart>| q.cart_id == "c1")
+            .returning(|_| StatePart::new(5, cart("c1", [])));
+        snapshotter
+            .expect_load_snapshot()
+            .once()
+            .withf(|q: &StatePart<Cart>| q.cart_id == "c2")
+            .returning(|_| StatePart::new(3, cart("c2", [])));
+        snapshotter
+            .expect_store_snapshot()
+            .times(2)
+            .returning(|_: &StatePart<Cart>| Ok(()));
+
+        let event_store = MockEventStore::new(mock_store);
+        let state_store =
+            EventSourcedDecisionStateStore::new(event_store, WithSnapshot::new(snapshotter));
+        let state = (cart("c1", []), cart("c2", [])).into_state_part();
+        let (_, version) = block_on(state_store.load(state)).unwrap();
+
+        assert_eq!(version, 5);
+    }
+}

--- a/disintegrate/src/event.rs
+++ b/disintegrate/src/event.rs
@@ -28,13 +28,13 @@ pub trait Event {
     fn name(&self) -> &'static str;
 }
 
-/// Wrapper for a persisted event
+/// Wrapper for a persisted event.
 ///
 /// It contains an ID assigned by the event store and the event itself.
 #[derive(Debug, Clone)]
 pub struct PersistedEvent<E: Event> {
-    id: i64,
-    event: E,
+    pub(crate) id: i64,
+    pub(crate) event: E,
 }
 
 impl<E: Event> PersistedEvent<E> {

--- a/disintegrate/src/event_store.rs
+++ b/disintegrate/src/event_store.rs
@@ -16,7 +16,7 @@ use async_trait::async_trait;
 use futures::stream::BoxStream;
 use std::error::Error as StdError;
 
-/// A trait representing an event store.
+/// An event store.
 ///
 /// This trait provides methods for streaming events and appending events to the event store.
 #[async_trait]

--- a/disintegrate/src/lib.rs
+++ b/disintegrate/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../../README.md")]
+
 pub mod decision;
 pub mod domain_identifier;
 mod event;
@@ -8,29 +10,59 @@ pub mod stream_query;
 mod testing;
 pub mod utils;
 
-pub use crate::decision::{Decision, DecisionMaker, State};
+#[doc(inline)]
+pub use crate::decision::{
+    Decision, DecisionMaker, DecisionStateStore, EventSourcedDecisionStateStore, IntoState,
+    IntoStatePart, MultiState, NoSnapshot, SnapshotConfig, StateMutate, StatePart, StateQuery,
+    StateSnapshotter, WithSnapshot,
+};
+#[doc(inline)]
 pub use crate::domain_identifier::{DomainIdentifier, DomainIdentifierSet};
+#[doc(inline)]
 pub use crate::event::{Event, EventSchema, PersistedEvent};
+#[doc(inline)]
 pub use crate::event_store::EventStore;
+#[doc(inline)]
 pub use crate::identifier::Identifier;
+#[doc(inline)]
 pub use crate::listener::EventListener;
+#[doc(inline)]
 pub use crate::stream_query::{query, StreamQuery};
+#[doc(inline)]
 pub use crate::testing::TestHarness;
 
+pub type BoxDynError = Box<dyn std::error::Error + 'static + Send + Sync>;
+
 #[cfg(feature = "macros")]
-pub mod macros {
-    pub use disintegrate_macros::Event;
-}
+pub use disintegrate_macros::{Event, StateQuery};
 
 #[cfg(feature = "serde")]
 pub mod serde {
+    //! # Event Store Serialization Deserializaion.
     #[cfg(feature = "serde-avro")]
+    #[doc(inline)]
     pub use disintegrate_serde::serde::avro;
     #[cfg(feature = "serde-json")]
+    #[doc(inline)]
     pub use disintegrate_serde::serde::json;
     #[cfg(feature = "serde-prost")]
+    #[doc(inline)]
     pub use disintegrate_serde::serde::prost;
     #[cfg(feature = "serde-protobuf")]
+    #[doc(inline)]
     pub use disintegrate_serde::serde::protobuf;
+    #[doc(inline)]
     pub use disintegrate_serde::{Deserializer, Serde, Serializer};
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! all_the_tuples {
+    ($name:ident) => {
+        $name!([], T1);
+        $name!([T1], T2);
+        $name!([T1, T2], T3);
+        $name!([T1, T2, T3], T4);
+        $name!([T1, T2, T3, T4], T5);
+    };
 }

--- a/disintegrate/src/stream_query.rs
+++ b/disintegrate/src/stream_query.rs
@@ -14,7 +14,7 @@
 use core::fmt::Debug;
 use std::marker::PhantomData;
 
-use crate::identifier::Identifier;
+use crate::{identifier::Identifier, Event};
 
 /// Represents a query for filtering event streams.
 ///
@@ -25,52 +25,69 @@ use crate::identifier::Identifier;
 pub struct StreamQuery<E: Clone> {
     /// An optional filter applied to the event stream. It determines which events are included
     /// in the query results based on certain criteria.
-    filter: Option<StreamFilter>,
-    /// The starting point of the event stream query. It represents the position in the
-    /// event stream from where the query begins, and only events occurring after the origin will be considered.
-    origin: i64,
-    /// It contains the list of events that will be excluded from the query result.
-    /// For instance, this can be used to define the validation query of a `Decision` from the `State` query.
-    excluded_events: &'static [&'static str],
+    filter: StreamFilter,
     /// A marker indicating the event type associated with the stream query.
     event_type: PhantomData<E>,
 }
 
 impl<E: Clone> StreamQuery<E> {
     /// Returns the filter associated with the stream query, if any.
-    pub fn filter(&self) -> Option<&StreamFilter> {
-        self.filter.as_ref()
-    }
-
-    /// Returns the origin of the event stream query.
-    pub fn origin(&self) -> i64 {
-        self.origin
-    }
-
-    /// Returns the list of excluded events.
-    pub fn excluded_events(&self) -> &'static [&'static str] {
-        self.excluded_events
+    pub fn filter(&self) -> &StreamFilter {
+        &self.filter
     }
 
     /// Changes the origin of the event stream query and returns the modified query.
-    pub fn change_origin(mut self, origin: i64) -> Self {
-        self.origin = origin;
+    pub fn change_origin(mut self, id: i64) -> Self {
+        self.filter = and(origin(id), self.filter);
         self
     }
 
     /// Sets the list of event types that will be excluded from the query result.
     pub fn exclude_events(mut self, types: &'static [&'static str]) -> Self {
-        self.excluded_events = types;
+        self.filter = and(exclude_events(types), self.filter);
         self
+    }
+
+    pub fn convert<U>(&self) -> StreamQuery<U>
+    where
+        E: Event + Into<U>,
+        U: Event + Clone,
+    {
+        StreamQuery {
+            filter: self.filter.clone(),
+            event_type: PhantomData,
+        }
+    }
+
+    pub fn union<U: Event + Clone, O: Clone>(&self, other: &StreamQuery<O>) -> StreamQuery<U>
+    where
+        E: Event + Into<U>,
+        O: Event + Into<U>,
+    {
+        StreamQuery {
+            filter: or(self.filter.clone(), other.filter.clone()),
+            event_type: PhantomData,
+        }
     }
 }
 
+impl<E: Clone> PartialEq for StreamQuery<E> {
+    fn eq(&self, other: &Self) -> bool {
+        self.filter == other.filter
+    }
+}
+
+impl<E: Clone> Eq for StreamQuery<E> {}
+
 /// Creates a new stream query with the given filter.
-pub fn query<E: Clone>(filter: Option<StreamFilter>) -> StreamQuery<E> {
+pub fn query<E: Event + Clone>(filter: Option<StreamFilter>) -> StreamQuery<E> {
+    let filter = if let Some(filter) = filter {
+        and(events(E::SCHEMA.types), filter)
+    } else {
+        events(E::SCHEMA.types)
+    };
     StreamQuery {
         filter,
-        origin: 0,
-        excluded_events: &[],
         event_type: PhantomData,
     }
 }
@@ -78,6 +95,11 @@ pub fn query<E: Clone>(filter: Option<StreamFilter>) -> StreamQuery<E> {
 /// Creates a new filter that allows you to specify a subset of events to pass through.
 pub fn events(names: &'static [&'static str]) -> StreamFilter {
     StreamFilter::Events { names }
+}
+
+/// Creates a new filter that allows you to specify a subset of events to filter out.
+pub fn exclude_events(names: &'static [&'static str]) -> StreamFilter {
+    StreamFilter::ExcludeEvents { names }
 }
 
 /// Creates a filter that checks for equality between an identifier and a value.
@@ -104,17 +126,22 @@ pub fn or(l: StreamFilter, r: StreamFilter) -> StreamFilter {
     }
 }
 
+/// Creates a origin filter that requires events after a specified id.
+pub fn origin(id: i64) -> StreamFilter {
+    StreamFilter::Origin { id }
+}
+
 /// Creates a stream query with a given event type and filter.
 #[macro_export]
 macro_rules! query {
     ($event_ty: ty) => {{
-        $crate::query!(0; $event_ty)
+        $crate::stream_query::query::<$event_ty>(None)
     }};
     ($event_ty:ty,  $($filter:tt)+ ) => {{
-        $crate::query!(0; $event_ty, $($filter)*)
+        $crate::stream_query::query::<$event_ty>(Some($crate::filter!($event_ty, $($filter)*)))
     }};
     ($origin:expr; $event_ty:ty) => {{
-        $crate::stream_query::query::<$event_ty>(None).change_origin($origin)
+        $crate::stream_query::query::<$event_ty>(Some($crate::stream_query::origin($origin)))
     }};
     ($origin:expr; $event_ty:ty,  $($filter:tt)+ ) => {{
         $crate::stream_query::query::<$event_ty>(Some($crate::filter!($event_ty, $($filter)*))).change_origin($origin)
@@ -124,7 +151,7 @@ macro_rules! query {
 /// A convenient macro to get the list of event types as a list of `&'static str`.
 /// It performs compile-time checks to guarantee that the specified variants exist.  
 #[macro_export]
-macro_rules! events_types{
+macro_rules! event_types{
     ($event_ty:ty, [$($events:ty),+]) =>{
         {
             use $crate::Event;
@@ -144,8 +171,11 @@ macro_rules! events_types{
 #[doc(hidden)]
 macro_rules! filter {
     ($event_ty:ty, events[$($events:ty),+]) =>{
+            $crate::stream_query::events($crate::event_types!($event_ty, [$($events),+]))
+    };
+    ($event_ty:ty, exclude_events[$($events:ty),+]) =>{
 
-            $crate::stream_query::events($crate::events_types!($event_ty, [$($events),+]))
+            $crate::stream_query::exclude_events($crate::event_types!($event_ty, [$($events),+]))
 
     };
     ($event_ty:ty, $ident:ident == $value:expr) => {
@@ -166,6 +196,23 @@ macro_rules! filter {
     };
     ($event_ty:ty, ($($h:tt)+) or ($($t:tt)+)) => {
        $crate::stream_query::or($crate::filter!($event_ty, $($h)+), $crate::filter!($event_ty, $($t)+))
+    };
+}
+
+#[macro_export]
+macro_rules! union {
+    ($query:expr) =>{
+        Into::<$crate::stream_query::StreamQuery<_>>::into($query).convert()
+    };
+    ($query1:expr, $query2: expr) =>{
+        $crate::stream_query::StreamQuery::<_>::union(&Into::<$crate::stream_query::StreamQuery<_>>::into($query1),&Into::<$crate::stream_query::StreamQuery<_>>::into($query2))
+    };
+    ($query:expr, $($queries: expr),*) =>{
+        {
+                let mut result = $crate::union!($($queries),*);
+                result = $crate::stream_query::StreamQuery::<_>::union(&Into::<$crate::stream_query::StreamQuery<_>>::into($query), &result);
+                result
+        }
     };
 }
 
@@ -197,97 +244,60 @@ pub enum StreamFilter {
         /// The right operand of the OR operation.
         r: Box<StreamFilter>,
     },
-}
 
-/// Represents a filter evaluator used to evaluate stream filters.
-pub trait FilterEvaluator {
-    /// The result type produced by evaluating a filter.
-    type Result;
-    /// Evaluates the given filter and returns the result.
-    fn eval(&mut self, filter: &StreamFilter) -> Self::Result;
+    /// Requires that the event id is greater than the specified origin.
+    Origin { id: i64 },
+
+    /// Exclude the specified events.
+    ExcludeEvents {
+        /// The list of events to exclude.
+        names: &'static [&'static str],
+    },
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{domain_identifiers, ident, DomainIdentifierSet, Event, EventSchema};
-
-    #[derive(Clone)]
-    #[allow(dead_code)]
-    enum ShoppingCartEvent {
-        Added {
-            product_id: String,
-            cart_id: String,
-            quantity: i64,
-        },
-        Removed {
-            product_id: String,
-            cart_id: String,
-            quantity: i64,
-        },
-    }
-
-    impl Event for ShoppingCartEvent {
-        const SCHEMA: EventSchema = EventSchema {
-            types: &["Added", "Removed"],
-            domain_identifiers: &["cart_id", "product_id"],
-        };
-        fn name(&self) -> &'static str {
-            match self {
-                ShoppingCartEvent::Added { .. } => "ShoppingCartAdded",
-                ShoppingCartEvent::Removed { .. } => "ShoppingCartRemoved",
-            }
-        }
-        fn domain_identifiers(&self) -> DomainIdentifierSet {
-            match self {
-                ShoppingCartEvent::Added {
-                    product_id,
-                    cart_id,
-                    ..
-                } => domain_identifiers! {product_id: product_id, cart_id: cart_id},
-                ShoppingCartEvent::Removed {
-                    product_id,
-                    cart_id,
-                    ..
-                } => domain_identifiers! {product_id: product_id, cart_id: cart_id},
-            }
-        }
-    }
+    use crate::ident;
+    use crate::utils::tests::*;
 
     #[test]
     fn it_can_create_stream_query_with_filter() {
-        let filter = eq(ident!(#id), "123");
-        let query_no_filter: StreamQuery<()> = query(None::<StreamFilter>);
-        assert_eq!(query_no_filter.filter(), None);
-
-        let query_with_filter: StreamQuery<()> = query(Some(filter.clone()));
-        assert_eq!(query_with_filter.filter(), Some(&filter));
+        let filter = eq(ident!(#cart_id), "123");
+        let query_with_filter: StreamQuery<ShoppingCartEvent> = query(Some(filter));
+        assert_eq!(
+            query_with_filter.filter(),
+            &and(
+                events(ShoppingCartEvent::SCHEMA.types),
+                eq(ident!(#cart_id), "123")
+            )
+        );
     }
 
     #[test]
     fn it_can_create_stream_query_macros() {
-        let query_no_filter: StreamQuery<ShoppingCartEvent> = query!(ShoppingCartEvent);
-        assert_eq!(query_no_filter.filter(), None);
-
         let query_with_filter: StreamQuery<ShoppingCartEvent> =
             query!(ShoppingCartEvent, cart_id == "123");
         assert_eq!(
             query_with_filter.filter(),
-            Some(&eq(ident!(#cart_id), "123"))
+            &and(
+                events(ShoppingCartEvent::SCHEMA.types),
+                eq(ident!(#cart_id), "123")
+            )
         );
 
         let query_with_origin: StreamQuery<ShoppingCartEvent> =
             query!(42; ShoppingCartEvent, cart_id == "123");
-        assert_eq!(query_with_origin.origin(), 42);
         assert_eq!(
             query_with_origin.filter(),
-            Some(&eq(ident!(#cart_id), "123"))
+            &and(
+                origin(42),
+                and(
+                    events(ShoppingCartEvent::SCHEMA.types),
+                    eq(ident!(#cart_id), "123")
+                )
+            )
         );
-
-        let query_with_origin_no_filter: StreamQuery<ShoppingCartEvent> =
-            query!(42; ShoppingCartEvent);
-        assert_eq!(query_with_origin_no_filter.origin(), 42);
-        assert_eq!(query_with_origin_no_filter.filter(), None);
     }
 
     #[test]
@@ -295,36 +305,48 @@ mod tests {
         let filter = filter!(ShoppingCartEvent, cart_id == "123");
         assert_eq!(filter, eq(ident!(#cart_id), "123"));
 
-        let filter = filter!(ShoppingCartEvent, (cart_id == "123") and (product_id == "345"));
+        let filter = filter!(ShoppingCartEvent, (cart_id == "123") and (item_id == "345"));
         assert_eq!(
             filter,
-            and(eq(ident!(#cart_id), "123"), eq(ident!(#product_id), "345"))
+            and(eq(ident!(#cart_id), "123"), eq(ident!(#item_id), "345"))
         );
 
-        let filter = filter!(ShoppingCartEvent, (cart_id == "123") or (product_id == "345"));
+        let filter = filter!(ShoppingCartEvent, (cart_id == "123") or (item_id == "345"));
         assert_eq!(
             filter,
-            or(eq(ident!(#cart_id), "123"), eq(ident!(#product_id), "345"))
+            or(eq(ident!(#cart_id), "123"), eq(ident!(#item_id), "345"))
         );
 
-        let filter = filter!(ShoppingCartEvent, ((cart_id == "123") and (product_id == "345")) or
-         ((cart_id == "678") and (product_id == "901")));
+        let filter = filter!(ShoppingCartEvent, ((cart_id == "123") and (item_id == "345")) or
+         ((cart_id == "678") and (item_id == "901")));
         assert_eq!(
             filter,
             or(
-                and(eq(ident!(#cart_id), "123"), eq(ident!(#product_id), "345")),
-                and(eq(ident!(#cart_id), "678"), eq(ident!(#product_id), "901"))
+                and(eq(ident!(#cart_id), "123"), eq(ident!(#item_id), "345")),
+                and(eq(ident!(#cart_id), "678"), eq(ident!(#item_id), "901"))
             )
         );
 
-        let filter = filter!(ShoppingCartEvent, (cart_id == "123") and ((product_id == "345") and (events[Added, Removed])));
+        let filter = filter!(ShoppingCartEvent, (cart_id == "123") and ((item_id == "345") and (events[ItemAdded, ItemRemoved])));
         assert_eq!(
             filter,
             and(
                 eq(ident!(#cart_id), "123"),
                 and(
-                    eq(ident!(#product_id), "345"),
-                    events(&["Added", "Removed"])
+                    eq(ident!(#item_id), "345"),
+                    events(ShoppingCartEvent::SCHEMA.types),
+                )
+            )
+        );
+
+        let filter = filter!(ShoppingCartEvent, (cart_id == "123") and ((item_id == "345") and (exclude_events[ItemAdded, ItemRemoved])));
+        assert_eq!(
+            filter,
+            and(
+                eq(ident!(#cart_id), "123"),
+                and(
+                    eq(ident!(#item_id), "345"),
+                    exclude_events(&["ItemAdded", "ItemRemoved"])
                 )
             )
         );
@@ -332,8 +354,28 @@ mod tests {
 
     #[test]
     fn it_exclude_events() {
-        let query_with_exceptions: StreamQuery<()> =
-            query(None::<StreamFilter>).exclude_events(events_types!(ShoppingCartEvent, [Added]));
-        assert_eq!(query_with_exceptions.excluded_events, &["Added"]);
+        let query_with_exceptions: StreamQuery<ShoppingCartEvent> =
+            query(None).exclude_events(event_types!(ShoppingCartEvent, [ItemAdded]));
+        assert_eq!(
+            query_with_exceptions.filter(),
+            &and(
+                exclude_events(&["ItemAdded"]),
+                events(ShoppingCartEvent::SCHEMA.types)
+            )
+        );
+    }
+
+    #[test]
+    fn it_unions_two_queries() {
+        let query1: StreamQuery<ShoppingCartEvent> = query(Some(origin(0)));
+        let query2: StreamQuery<ShoppingCartEvent> = query(Some(origin(1)));
+        let union: StreamQuery<ShoppingCartEvent> = query1.union(&query2);
+        assert_eq!(
+            union.filter(),
+            &or(
+                and(events(ShoppingCartEvent::SCHEMA.types), origin(0)),
+                and(events(ShoppingCartEvent::SCHEMA.types), origin(1))
+            )
+        );
     }
 }

--- a/disintegrate/src/utils.rs
+++ b/disintegrate/src/utils.rs
@@ -1,3 +1,5 @@
+#![doc(hidden)]
+
 #[macro_export]
 #[doc(hidden)]
 macro_rules! const_slice_unique {
@@ -163,4 +165,242 @@ pub const fn eq(lhs: &str, rhs: &str) -> bool {
     }
 
     true
+}
+
+#[cfg(test)]
+pub mod tests {
+    use async_trait::async_trait;
+    use futures::{
+        stream::{self, BoxStream},
+        StreamExt,
+    };
+    use mockall::mock;
+    use serde::{de::DeserializeOwned, Deserialize, Serialize};
+    use std::{error::Error as StdError, fmt};
+
+    use crate::{
+        domain_identifiers, query, BoxDynError, Decision, DomainIdentifierSet, Event, EventSchema,
+        EventStore, PersistedEvent, StateMutate, StatePart, StateQuery, StateSnapshotter,
+        StreamQuery,
+    };
+
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    #[serde(tag = "event_type", rename_all = "snake_case")]
+    pub enum ShoppingCartEvent {
+        ItemAdded { item_id: String, cart_id: String },
+        ItemRemoved { item_id: String, cart_id: String },
+    }
+
+    pub fn item_added_event(item_id: &str, cart_id: &str) -> ShoppingCartEvent {
+        ShoppingCartEvent::ItemAdded {
+            item_id: item_id.to_string(),
+            cart_id: cart_id.to_string(),
+        }
+    }
+
+    pub fn item_removed_event(item_id: &str, cart_id: &str) -> ShoppingCartEvent {
+        ShoppingCartEvent::ItemRemoved {
+            item_id: item_id.to_string(),
+            cart_id: cart_id.to_string(),
+        }
+    }
+
+    pub fn event_stream<E: Event + Clone>(
+        events: impl Into<Vec<E>>,
+    ) -> Vec<Result<PersistedEvent<E>, Error>> {
+        events
+            .into()
+            .into_iter()
+            .enumerate()
+            .map(|(id, event)| Ok(PersistedEvent::new((id + 1) as i64, event)))
+            .collect()
+    }
+
+    impl Event for ShoppingCartEvent {
+        const SCHEMA: EventSchema = EventSchema {
+            types: &["ItemAdded", "ItemRemoved"],
+            domain_identifiers: &["cart_id", "item_id"],
+        };
+        fn name(&self) -> &'static str {
+            match self {
+                ShoppingCartEvent::ItemAdded { .. } => "ItemAdded",
+                ShoppingCartEvent::ItemRemoved { .. } => "ItemRemoved",
+            }
+        }
+        fn domain_identifiers(&self) -> DomainIdentifierSet {
+            match self {
+                ShoppingCartEvent::ItemAdded {
+                    item_id, cart_id, ..
+                } => domain_identifiers! {item_id: item_id, cart_id: cart_id},
+                ShoppingCartEvent::ItemRemoved {
+                    item_id, cart_id, ..
+                } => domain_identifiers! {item_id: item_id, cart_id: cart_id},
+            }
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct MockEventStore<D> {
+        pub database: D,
+    }
+    impl<D> MockEventStore<D> {
+        pub fn new(database: D) -> Self {
+            Self { database }
+        }
+    }
+
+    #[derive(Debug)]
+    pub struct Error;
+    impl StdError for Error {}
+    impl fmt::Display for Error {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "test error")
+        }
+    }
+
+    pub trait Database {
+        fn stream<QE: Event + Clone + 'static + Send + Sync>(
+            &self,
+            query: &StreamQuery<QE>,
+        ) -> Vec<Result<PersistedEvent<QE>, Error>>;
+
+        fn append<QE: Event + Clone + 'static + Send + Sync>(
+            &self,
+            events: Vec<ShoppingCartEvent>,
+            query: StreamQuery<QE>,
+            last_event_id: i64,
+        ) -> Vec<PersistedEvent<ShoppingCartEvent>>;
+    }
+
+    mock! {
+        pub Database {}
+        impl Database for Database {
+        fn stream<QE: Event + Clone + 'static + Send + Sync>(
+            &self,
+            query: &StreamQuery<QE>,
+        ) -> Vec<Result<PersistedEvent<QE>, Error>>;
+
+        fn append<QE: Event + Clone + 'static + Send + Sync>(
+            &self,
+            events: Vec<ShoppingCartEvent>,
+            query: StreamQuery<QE>,
+            last_event_id: i64,
+        ) -> Vec<PersistedEvent<ShoppingCartEvent>>;
+        }
+        impl Clone for Database {
+            fn clone(&self) -> Self;
+        }
+    }
+
+    #[async_trait]
+    impl<D: Database + Sync> EventStore<ShoppingCartEvent> for MockEventStore<D> {
+        type Error = Error;
+
+        fn stream<'a, QE>(
+            &'a self,
+            query: &'a StreamQuery<QE>,
+        ) -> BoxStream<Result<PersistedEvent<QE>, Self::Error>>
+        where
+            QE: TryFrom<ShoppingCartEvent> + Event + 'static + Clone + Send + Sync,
+            <QE as TryFrom<ShoppingCartEvent>>::Error: StdError + 'static + Send + Sync,
+        {
+            stream::iter(self.database.stream(query)).boxed()
+        }
+
+        async fn append<QE>(
+            &self,
+            events: Vec<ShoppingCartEvent>,
+            query: StreamQuery<QE>,
+            last_event_id: i64,
+        ) -> Result<Vec<PersistedEvent<ShoppingCartEvent>>, Self::Error>
+        where
+            QE: Event + 'static + Clone + Send + Sync,
+        {
+            Ok(self.database.append(events, query, last_event_id))
+        }
+    }
+
+    #[derive(Default, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+    pub struct Cart {
+        pub cart_id: String,
+        pub items: Vec<String>,
+    }
+
+    impl Cart {
+        pub fn new(cart_id: &str) -> Self {
+            Self {
+                cart_id: cart_id.into(),
+                ..Default::default()
+            }
+        }
+    }
+
+    pub fn cart<const N: usize>(cart_id: &str, items: [String; N]) -> Cart {
+        Cart {
+            cart_id: cart_id.to_string(),
+            items: Vec::from(items),
+        }
+    }
+
+    impl StateQuery for Cart {
+        const NAME: &'static str = "Cart";
+        type Event = ShoppingCartEvent;
+
+        fn query(&self) -> StreamQuery<Self::Event> {
+            query!(ShoppingCartEvent, cart_id == self.cart_id.clone())
+        }
+    }
+
+    impl StateMutate for Cart {
+        fn mutate(&mut self, event: Self::Event) {
+            match event {
+                ShoppingCartEvent::ItemAdded { item_id, .. } => {
+                    self.items.push(item_id);
+                }
+                ShoppingCartEvent::ItemRemoved { item_id, .. } => {
+                    let index = self.items.iter().position(|i| i == &item_id).unwrap();
+                    self.items.remove(index);
+                }
+            }
+        }
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    pub struct CartError(pub String);
+    impl StdError for CartError {}
+
+    impl fmt::Display for CartError {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "{}", self.0)
+        }
+    }
+
+    mock! {
+            pub Decision{}
+            impl Decision for Decision {
+                type Event = ShoppingCartEvent;
+                type StateQuery = Cart;
+                type Error = CartError;
+
+            fn state_query(&self) -> <Self as Decision>::StateQuery;
+            fn validation_query(&self) -> Option<StreamQuery<ShoppingCartEvent>>;
+            fn process(&self, _state: &<Self as Decision>::StateQuery) -> Result<Vec<<Self as Decision>::Event>, <Self as Decision>::Error>;
+        }
+    }
+
+    mock! {
+            pub StateSnapshotter{}
+            #[async_trait]
+            impl StateSnapshotter for StateSnapshotter {
+                async fn load_snapshot<S>(&self, default: StatePart<S>) -> StatePart<S>
+                where
+                    S: Send + Sync + DeserializeOwned + StateQuery + 'static;
+                async fn store_snapshot<S>(&self, state: &StatePart<S>) -> Result<(), BoxDynError>
+                where
+                    S: Send + Sync + Serialize + StateQuery + 'static;
+            }
+            impl Clone for StateSnapshotter {
+                fn clone(&self) -> Self;
+            }
+    }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   pgsql:
-    image: postgres:15.2
+    image: postgres:16
     restart: always
     environment:
       - POSTGRES_USER=postgres

--- a/examples/banking/Cargo.toml
+++ b/examples/banking/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "banking"
 version = "0.1.0"
-edition = "2021"
 publish = false
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+license.workspace = true
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
 
 [dependencies]
-disintegrate = { version = "0.5.0", path = "../../disintegrate", features = ["macros", "serde-json"] }
-disintegrate-postgres = { version = "0.5.0", path = "../../disintegrate-postgres" }
+disintegrate = { version = "0.6.0", path = "../../disintegrate", features = ["macros", "serde-json"] }
+disintegrate-postgres = { version = "0.6.0", path = "../../disintegrate-postgres" }
 tokio = { version = "1.29.1", features = ["macros", "rt-multi-thread", "signal"] }
 serde = { version = "1.0.190", features = ["derive"] }
 thiserror = "1.0.50"

--- a/examples/banking/tests/validation_query_test.js
+++ b/examples/banking/tests/validation_query_test.js
@@ -17,8 +17,8 @@ function buildAmountPayload(amount){
     });
 }
 
-function requestOpenAccount(id, amount) {
-    return http.post(`${serverUrl}/account/${id}/open`, buildAmountPayload(amount), CONFIG);
+function requestOpenAccount(id) {
+    return http.post(`${serverUrl}/account/${id}/open`, params=CONFIG);
 }
 
 
@@ -37,7 +37,8 @@ function requestTransfer(id, beneficiary_id, amount) {
 export function setup() {
    // Register accounts 
    for(let i = 1; i <= USERS; i ++){
-   	requestOpenAccount(`account_${i}`, 100);
+   	requestOpenAccount(`account_${i}`);
+   	requestDeposit(`account_${i}`, 100);
    }
 }
 

--- a/examples/cart/Cargo.toml
+++ b/examples/cart/Cargo.toml
@@ -1,12 +1,15 @@
 [package]
 name = "cart"
 version = "0.1.0"
-edition = "2021"
 publish = false
+license.workspace = true
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
 
 [dependencies]
-disintegrate = { version = "0.5.0", path = "../../disintegrate", features = ["macros", "serde-json"] }
-disintegrate-postgres = { version = "0.5.0", path = "../../disintegrate-postgres" }
+disintegrate = { version = "0.6.0", path = "../../disintegrate", features = ["macros", "serde-json"] }
+disintegrate-postgres = { version = "0.6.0", path = "../../disintegrate-postgres" }
 sqlx = { version = "0.7.2", features = [ "runtime-tokio-rustls" , "postgres" ] }
 tokio = { version = "1.29.1", features = ["macros", "rt-multi-thread", "signal"] }
 anyhow = "1.0.51"

--- a/examples/cart/src/event.rs
+++ b/examples/cart/src/event.rs
@@ -1,10 +1,11 @@
 #![allow(clippy::enum_variant_names)]
-use disintegrate::macros::Event;
+use disintegrate::Event;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Event, Serialize, Deserialize)]
 #[group(UserEvent, [UserCreated])]
-#[group(CartEvent, [ItemAdded, ItemRemoved, ItemUpdated])]
+#[group(CartEvent, [ItemAdded, ItemRemoved, ItemUpdated, CouponApplied])]
+#[group(CouponEvent, [CouponEmitted, CouponApplied])]
 pub enum DomainEvent {
     UserCreated {
         #[id]
@@ -30,5 +31,16 @@ pub enum DomainEvent {
         #[id]
         item_id: String,
         new_quantity: u32,
+    },
+    CouponEmitted {
+        #[id]
+        coupon_id: String,
+        quantity: u32,
+    },
+    CouponApplied {
+        #[id]
+        coupon_id: String,
+        #[id]
+        user_id: String,
     },
 }

--- a/examples/cart/src/main.rs
+++ b/examples/cart/src/main.rs
@@ -5,7 +5,7 @@ use cart::AddItem;
 use event::DomainEvent;
 
 use anyhow::{Ok, Result};
-use disintegrate::{serde::json::Json, DecisionMaker};
+use disintegrate::serde::json::Json;
 use disintegrate_postgres::PgEventStore;
 use sqlx::{postgres::PgConnectOptions, PgPool};
 
@@ -23,8 +23,8 @@ async fn main() -> Result<()> {
     // Create a PostgreSQL event store
     let event_store = PgEventStore::new(pool, serde).await?;
 
-    // Create a DecisionMaker
-    let decision_maker = DecisionMaker::new(event_store);
+    // Create a Postgres DecisionMaker
+    let decision_maker = disintegrate_postgres::decision_maker(event_store);
 
     // Make the decision. This performs the business decision and persists the changes into the
     // event store

--- a/examples/courses/Cargo.toml
+++ b/examples/courses/Cargo.toml
@@ -1,18 +1,20 @@
 [package]
 name = "courses"
 version = "0.1.0"
-edition = "2021"
 publish = false
-
+license.workspace = true
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
 
 [dependencies]
 anyhow = "1.0.71"
 async-trait = "0.1.74"
-disintegrate = {version = "0.5.0", path = "../../disintegrate", features = ["macros", "serde-prost"] }
-disintegrate-postgres = { version = "0.5.0", path = "../../disintegrate-postgres", features = ["listener"] }
+disintegrate = {version = "0.6.0", path = "../../disintegrate", features = ["macros", "serde-prost"] }
+disintegrate-postgres = { version = "0.6.0", path = "../../disintegrate-postgres", features = ["listener"] }
 opentelemetry = { version = "0.19.0", features = ["rt-tokio"] }
 opentelemetry-jaeger = { version = "0.18.0", features = ["rt-tokio"] }
-rust_decimal = "1.32.0"
+rust_decimal = "1.33.1"
 sqlx = { version = "0.7.2", features = [ "runtime-tokio-rustls" , "postgres" ] }
 thiserror = "1.0.50"
 tokio = { version = "1.29.1", features = ["macros", "rt-multi-thread", "signal"] }
@@ -21,8 +23,9 @@ tonic-health = "0.10.2"
 tonic-reflection = "0.10.2"
 tower = "0.4.13"
 tower-http = { version = "0.4.4", features = ["trace"] }
-prost = {version = "0.12.1"}
+prost = {version = "0.12.3"}
 dotenv = "0.15.0"
+serde = "1.0.193"
 
 [build-dependencies]
 tonic-build = { version = "0.10.2", features = ["prost"] }

--- a/examples/courses/src/application.rs
+++ b/examples/courses/src/application.rs
@@ -1,22 +1,23 @@
 mod commands;
 mod queries;
 
-use crate::{domain::DomainEvent, read_model};
-use disintegrate::{DecisionMaker, EventStore};
+use crate::{domain::DomainEvent, proto, read_model};
+use disintegrate::serde::prost::Prost;
+use disintegrate_postgres::{PgDecisionMaker, WithPgSnapshot};
+
+pub type DecisionMaker =
+    PgDecisionMaker<DomainEvent, Prost<DomainEvent, proto::Event>, WithPgSnapshot>;
 
 #[derive(Clone)]
-pub struct Application<ES> {
-    decision_maker: DecisionMaker<ES>,
+pub struct Application {
+    decision_maker: DecisionMaker,
     read_model: read_model::Repository,
 }
 
-impl<ES> Application<ES>
-where
-    ES: EventStore<DomainEvent>,
-{
-    pub fn new(event_store: ES, read_model: read_model::Repository) -> Self {
+impl Application {
+    pub fn new(decision_maker: DecisionMaker, read_model: read_model::Repository) -> Self {
         Self {
-            decision_maker: DecisionMaker::new(event_store),
+            decision_maker,
             read_model,
         }
     }

--- a/examples/courses/src/application/commands.rs
+++ b/examples/courses/src/application/commands.rs
@@ -1,16 +1,10 @@
 use super::Application;
 use crate::domain::{
-    CloseCourse, CreateCourse, DomainEvent, RegisterStudent, RenameCourse, SubscribeStudent,
-    UnsubscribeStudent,
+    CloseCourse, CreateCourse, RegisterStudent, RenameCourse, SubscribeStudent, UnsubscribeStudent,
 };
 use anyhow::Result;
-use disintegrate::EventStore;
 
-impl<ES> Application<ES>
-where
-    ES: EventStore<DomainEvent>,
-    <ES as disintegrate::EventStore<DomainEvent>>::Error: std::error::Error + 'static,
-{
+impl Application {
     pub async fn create_course(&self, command: CreateCourse) -> Result<()> {
         println!("create course id {}", command.course_id);
         self.decision_maker.make(command).await?;

--- a/examples/courses/src/application/queries.rs
+++ b/examples/courses/src/application/queries.rs
@@ -3,7 +3,7 @@ use crate::domain::CourseId;
 use crate::read_model;
 use anyhow::Result;
 
-impl<ES> Application<ES> {
+impl Application {
     pub async fn course_by_id(&self, course_id: CourseId) -> Result<Option<read_model::Course>> {
         println!("get course id {}", course_id);
         Ok(self.read_model.course_by_id(course_id).await?)

--- a/examples/courses/src/domain.rs
+++ b/examples/courses/src/domain.rs
@@ -3,13 +3,14 @@ mod student;
 mod subscription;
 mod unsubscription;
 pub use course::{CloseCourse, CourseError, CourseId, CreateCourse, RenameCourse};
-use disintegrate::macros::Event;
+use disintegrate::Event;
 pub use student::{RegisterStudent, StudentError, StudentId};
-pub use subscription::{SubscribeStudent, Subscription, SubscriptionError};
+pub use subscription::{SubscribeStudent, SubscriptionError};
 pub use unsubscription::{UnsubscribeStudent, UnsubscriptionError};
 
 #[derive(Debug, Clone, PartialEq, Eq, Event)]
-#[group(SubscriptionEvent, [CourseCreated, CourseClosed, StudentSubscribed, StudentUnsubscribed, StudentRegistered])]
+#[group(CourseSubscriptionEvent, [CourseCreated, CourseClosed, StudentSubscribed, StudentUnsubscribed])]
+#[group(StudentSubscriptionEvent, [StudentSubscribed, StudentUnsubscribed, StudentRegistered])]
 #[group(UnsubscriptionEvent, [StudentSubscribed, StudentUnsubscribed])]
 #[group(CourseEvent, [CourseCreated, CourseClosed, CourseRenamed])]
 #[group(StudentEvent, [StudentRegistered])]

--- a/examples/courses/src/domain/subscription.rs
+++ b/examples/courses/src/domain/subscription.rs
@@ -1,6 +1,7 @@
-use disintegrate::{events_types, Decision, State, StreamQuery};
+use disintegrate::{Decision, StateMutate, StateQuery};
+use serde::{Deserialize, Serialize};
 
-use super::{CourseId, DomainEvent, StudentId, SubscriptionEvent};
+use super::{CourseId, CourseSubscriptionEvent, DomainEvent, StudentId, StudentSubscriptionEvent};
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum SubscriptionError {
@@ -16,95 +17,78 @@ pub enum SubscriptionError {
     StudentHasTooManyCourses,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, StateQuery, Default, Deserialize, Serialize)]
+#[state_query(CourseSubscriptionEvent)]
 pub struct Course {
-    id: CourseId,
+    #[id]
+    course_id: CourseId,
     available_seats: u32,
     closed: bool,
 }
 
-#[derive(Debug, Clone, Default)]
+impl Course {
+    fn new(course_id: CourseId) -> Self {
+        Self {
+            course_id,
+            ..Default::default()
+        }
+    }
+}
+
+impl StateMutate for Course {
+    fn mutate(&mut self, event: Self::Event) {
+        match event {
+            CourseSubscriptionEvent::CourseCreated { seats, .. } => {
+                self.available_seats = seats;
+            }
+            CourseSubscriptionEvent::CourseClosed { .. } => {
+                self.closed = true;
+            }
+            CourseSubscriptionEvent::StudentSubscribed { .. } => {
+                self.available_seats -= 1;
+            }
+            CourseSubscriptionEvent::StudentUnsubscribed { .. } => {
+                self.available_seats += 1;
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, StateQuery, Default, Serialize, Deserialize)]
+#[state_query(StudentSubscriptionEvent)]
 pub struct Student {
-    id: StudentId,
+    #[id]
+    student_id: StudentId,
     subscribed_courses: Vec<CourseId>,
     registered: bool,
 }
 
-#[derive(Debug, Clone, Default)]
-pub struct Subscription {
-    course: Course,
-    student: Student,
-}
-
-impl Subscription {
-    pub fn new(course_id: CourseId, student_id: StudentId) -> Self {
+impl Student {
+    fn new(student_id: StudentId) -> Self {
         Self {
-            course: Course {
-                id: course_id,
-                ..Default::default()
-            },
-            student: Student {
-                id: student_id,
-                ..Default::default()
-            },
+            student_id,
+            ..Default::default()
         }
     }
 }
-
-impl State for Subscription {
-    type Event = SubscriptionEvent;
-
-    fn query(&self) -> StreamQuery<Self::Event> {
-        disintegrate::query!(
-            SubscriptionEvent,
-                (course_id == self.course.id) or
-                (student_id == self.student.id)
-        )
-    }
-
+impl StateMutate for Student {
     fn mutate(&mut self, event: Self::Event) {
         match event {
-            SubscriptionEvent::CourseCreated { seats, .. } => {
-                self.course.available_seats = seats;
+            StudentSubscriptionEvent::StudentSubscribed { course_id, .. } => {
+                self.subscribed_courses.push(course_id);
             }
-            SubscriptionEvent::CourseClosed { .. } => {
-                self.course.closed = true;
+            StudentSubscriptionEvent::StudentUnsubscribed { course_id, .. } => {
+                let index = self
+                    .subscribed_courses
+                    .iter()
+                    .position(|student_course_id| *student_course_id == course_id)
+                    .unwrap();
+                self.subscribed_courses.remove(index);
             }
-            SubscriptionEvent::StudentSubscribed {
-                student_id,
-                course_id,
-                ..
-            } => {
-                if self.course.id == course_id {
-                    self.course.available_seats -= 1;
-                }
-                if self.student.id == student_id {
-                    self.student.subscribed_courses.push(course_id);
-                }
-            }
-            SubscriptionEvent::StudentUnsubscribed {
-                student_id,
-                course_id,
-                ..
-            } => {
-                if self.course.id == course_id {
-                    self.course.available_seats += 1;
-                }
-                if self.student.id == student_id {
-                    let index = self
-                        .student
-                        .subscribed_courses
-                        .iter()
-                        .position(|student_course_id| *student_course_id == course_id)
-                        .unwrap();
-                    self.student.subscribed_courses.remove(index);
-                }
-            }
-            SubscriptionEvent::StudentRegistered { .. } => self.student.registered = true,
+            StudentSubscriptionEvent::StudentRegistered { .. } => self.registered = true,
         }
     }
 }
-
 pub struct SubscribeStudent {
     pub student_id: StudentId,
     pub course_id: CourseId,
@@ -122,39 +106,36 @@ impl SubscribeStudent {
 impl Decision for SubscribeStudent {
     type Event = DomainEvent;
 
-    type State = Subscription;
+    type StateQuery = (Course, Student);
 
     type Error = SubscriptionError;
 
-    fn default_state(&self) -> Self::State {
-        Subscription::new(self.course_id.clone(), self.student_id.clone())
-    }
-
-    fn validation_query(&self) -> Option<StreamQuery<<Self::State as State>::Event>> {
-        Some(
-            self.default_state()
-                .query()
-                .exclude_events(events_types!(DomainEvent, [StudentUnsubscribed])),
+    fn state_query(&self) -> Self::StateQuery {
+        (
+            Course::new(self.course_id.clone()),
+            Student::new(self.student_id.clone()),
         )
     }
 
-    fn process(&self, state: &Self::State) -> Result<Vec<Self::Event>, Self::Error> {
+    fn process(
+        &self,
+        (course, student): &Self::StateQuery,
+    ) -> Result<Vec<Self::Event>, Self::Error> {
         const MAX_STUDENT_COURSES: usize = 2;
 
-        if !state.student.registered {
+        if !student.registered {
             return Err(SubscriptionError::StudentNotRegistered);
         }
 
-        if state.course.closed {
+        if course.closed {
             return Err(SubscriptionError::CourseClosed);
         }
 
-        if state.course.available_seats == 0 {
+        if course.available_seats == 0 {
             return Err(SubscriptionError::NoSeatsAvailable);
         }
 
-        if state
-            .student
+        if student
             .subscribed_courses
             .iter()
             .any(|c| c == &self.course_id)
@@ -162,7 +143,7 @@ impl Decision for SubscribeStudent {
             return Err(SubscriptionError::StudentAlreadySubscribed);
         }
 
-        if state.student.subscribed_courses.len() >= MAX_STUDENT_COURSES {
+        if student.subscribed_courses.len() >= MAX_STUDENT_COURSES {
             return Err(SubscriptionError::StudentHasTooManyCourses);
         }
 
@@ -180,12 +161,12 @@ mod test {
     #[test]
     fn it_subscribes_a_student() {
         disintegrate::TestHarness::given([
-            SubscriptionEvent::CourseCreated {
+            DomainEvent::CourseCreated {
                 course_id: "some course".to_string(),
                 name: "some name".to_string(),
                 seats: 1,
             },
-            SubscriptionEvent::StudentRegistered {
+            DomainEvent::StudentRegistered {
                 student_id: "some student".to_string(),
                 name: "some name".to_string(),
             },
@@ -202,7 +183,7 @@ mod test {
 
     #[test]
     fn it_should_not_subscribe_an_unregistered_student() {
-        disintegrate::TestHarness::given([SubscriptionEvent::CourseCreated {
+        disintegrate::TestHarness::given([DomainEvent::CourseCreated {
             course_id: "some course".to_string(),
             name: "some name".to_string(),
             seats: 1,
@@ -217,16 +198,16 @@ mod test {
     #[test]
     fn it_should_not_subscribe_a_student_to_a_closed_course() {
         disintegrate::TestHarness::given([
-            SubscriptionEvent::CourseCreated {
+            DomainEvent::CourseCreated {
                 course_id: "some course".to_string(),
                 name: "some name".to_string(),
                 seats: 1,
             },
-            SubscriptionEvent::StudentRegistered {
+            DomainEvent::StudentRegistered {
                 student_id: "some student".to_string(),
                 name: "some name".to_string(),
             },
-            SubscriptionEvent::CourseClosed {
+            DomainEvent::CourseClosed {
                 course_id: "some course".to_string(),
             },
         ])
@@ -240,16 +221,16 @@ mod test {
     #[test]
     fn it_should_not_subscribe_a_student_to_a_full_course() {
         disintegrate::TestHarness::given([
-            SubscriptionEvent::CourseCreated {
+            DomainEvent::CourseCreated {
                 course_id: "some course".to_string(),
                 name: "some name".to_string(),
                 seats: 1,
             },
-            SubscriptionEvent::StudentRegistered {
+            DomainEvent::StudentRegistered {
                 student_id: "some student".to_string(),
                 name: "some name".to_string(),
             },
-            SubscriptionEvent::StudentSubscribed {
+            DomainEvent::StudentSubscribed {
                 student_id: "another student".to_string(),
                 course_id: "some course".to_string(),
             },
@@ -264,16 +245,16 @@ mod test {
     #[test]
     fn it_should_not_subscribe_a_student_that_is_already_subscribed() {
         disintegrate::TestHarness::given([
-            SubscriptionEvent::CourseCreated {
+            DomainEvent::CourseCreated {
                 course_id: "some course".to_string(),
                 name: "some name".to_string(),
                 seats: 2,
             },
-            SubscriptionEvent::StudentRegistered {
+            DomainEvent::StudentRegistered {
                 student_id: "some student".to_string(),
                 name: "some name".to_string(),
             },
-            SubscriptionEvent::StudentSubscribed {
+            DomainEvent::StudentSubscribed {
                 student_id: "some student".to_string(),
                 course_id: "some course".to_string(),
             },
@@ -288,20 +269,20 @@ mod test {
     #[test]
     fn it_should_not_subscribe_a_student_that_attends_two_courses() {
         disintegrate::TestHarness::given([
-            SubscriptionEvent::CourseCreated {
+            DomainEvent::CourseCreated {
                 course_id: "some course".to_string(),
                 name: "some name".to_string(),
                 seats: 1,
             },
-            SubscriptionEvent::StudentRegistered {
+            DomainEvent::StudentRegistered {
                 student_id: "some student".to_string(),
                 name: "some name".to_string(),
             },
-            SubscriptionEvent::StudentSubscribed {
+            DomainEvent::StudentSubscribed {
                 student_id: "some student".to_string(),
                 course_id: "another course".to_string(),
             },
-            SubscriptionEvent::StudentSubscribed {
+            DomainEvent::StudentSubscribed {
                 student_id: "some student".to_string(),
                 course_id: "yet another course".to_string(),
             },

--- a/examples/courses/src/grpc.rs
+++ b/examples/courses/src/grpc.rs
@@ -1,29 +1,24 @@
 use async_trait::async_trait;
-use disintegrate::EventStore;
 
 use crate::{
     application::Application,
-    domain::{self, DomainEvent},
+    domain::{self},
     proto,
 };
 
 #[derive(Clone)]
-pub struct CourseApi<ES> {
-    app: Application<ES>,
+pub struct CourseApi {
+    app: Application,
 }
 
-impl<ES> CourseApi<ES> {
-    pub fn new(app: Application<ES>) -> Self {
+impl CourseApi {
+    pub fn new(app: Application) -> Self {
         Self { app }
     }
 }
 
 #[async_trait]
-impl<ES> proto::course_server::Course for CourseApi<ES>
-where
-    ES: EventStore<DomainEvent> + Send + Sync + 'static,
-    <ES as disintegrate::EventStore<DomainEvent>>::Error: std::error::Error + 'static,
-{
+impl proto::course_server::Course for CourseApi {
     async fn create(
         &self,
         request: tonic::Request<proto::CreateCourseRequest>,
@@ -93,22 +88,18 @@ where
 }
 
 #[derive(Clone)]
-pub struct StudentApi<ES> {
-    app: Application<ES>,
+pub struct StudentApi {
+    app: Application,
 }
 
-impl<ES> StudentApi<ES> {
-    pub fn new(app: Application<ES>) -> Self {
+impl StudentApi {
+    pub fn new(app: Application) -> Self {
         Self { app }
     }
 }
 
 #[async_trait]
-impl<ES> proto::student_server::Student for StudentApi<ES>
-where
-    ES: EventStore<DomainEvent> + Send + Sync + 'static,
-    <ES as disintegrate::EventStore<DomainEvent>>::Error: std::error::Error + 'static,
-{
+impl proto::student_server::Student for StudentApi {
     async fn register(
         &self,
         request: tonic::Request<proto::RegisterStudentRequest>,
@@ -126,22 +117,18 @@ where
 }
 
 #[derive(Clone)]
-pub struct SubscriptionApi<ES> {
-    app: Application<ES>,
+pub struct SubscriptionApi {
+    app: Application,
 }
 
-impl<ES> SubscriptionApi<ES> {
-    pub fn new(app: Application<ES>) -> Self {
+impl SubscriptionApi {
+    pub fn new(app: Application) -> Self {
         Self { app }
     }
 }
 
 #[async_trait]
-impl<ES> proto::subscription_server::Subscription for SubscriptionApi<ES>
-where
-    ES: EventStore<DomainEvent> + Send + Sync + 'static,
-    <ES as disintegrate::EventStore<DomainEvent>>::Error: std::error::Error + 'static,
-{
+impl proto::subscription_server::Subscription for SubscriptionApi {
     async fn subscribe(
         &self,
         request: tonic::Request<proto::SubscribeStudentRequest>,

--- a/examples/courses/tests/subscriptions_concurrency_test.js
+++ b/examples/courses/tests/subscriptions_concurrency_test.js
@@ -3,12 +3,8 @@ import { check, sleep } from 'k6';
 import exec from 'k6/execution';
 
 const serverUrl = 'localhost:10437';
+const COURSES = 10;
 const USERS = 500;
-const course = {
-    course_id: 'course1',
-    name: 'Introduction to Programming',
-    seats: 100,
-};
 
 export let options = {
     vus: USERS,
@@ -19,9 +15,17 @@ const client = new grpc.Client();
 client.load(['../proto'], 'api.proto');
 
 export function setup() {
-    // Create course
+    // Create courses
     client.connect(serverUrl, { plaintext: true });
-    client.invoke('api.Course/Create', course);
+    for (let i = 1; i <= COURSES; i++) {
+        const course = {
+            course_id: `course${i}`,
+            name: 'Introduction to Programming',
+            seats: 100,
+        };
+        const res = client.invoke('api.Course/Create', course);
+        check(res, { 'course created': (r) => r && r.status === grpc.StatusOK });
+    }
     // Register students
     for (let i = 1; i <= USERS; i++) {
         const student = {
@@ -37,14 +41,16 @@ export function setup() {
 // Each virtual user subscribes one specific student to the course
 export default function (data) {
     client.connect(serverUrl, { plaintext: true });
+    const course_id = Math.floor(Math.random() * COURSES) + 1;
     const subscription = {
-        course_id: course.course_id,
+        course_id: `course${course_id}`,
         student_id: `student${exec.vu.idInTest}`,
     };
     const res = client.invoke('api.Subscription/Subscribe', subscription);
     check(res, { 'student subscribed successfully': (r) => r && r.status === grpc.StatusOK });
-    check(res, { 'student already subscribed error': (r) => r && r.status === grpc.StatusInternal && r.error.message === 'student already subscribed' });
-    check(res, { 'course no seats available': (r) => r && r.status === grpc.StatusInternal && r.error.message === 'no seats available' });
-    check(res, { 'concurrent modification error': (r) => r && r.status === grpc.StatusInternal && r.error.message === 'concurrent modification error' });
+    check(res, { 'student already subscribed error': (r) => r && r.status === grpc.StatusInternal && r.error.message.includes('student already subscribed') });
+    check(res, { 'student has too many courses error': (r) => r && r.status === grpc.StatusInternal && r.error.message.includes('student has too many courses') });
+    check(res, { 'course no seats available error': (r) => r && r.status === grpc.StatusInternal && r.error.message.includes('no seats available') });
+    check(res, { 'concurrent modification error': (r) => r && r.status === grpc.StatusInternal && r.error.message.includes('concurrent modification error') });
     client.close();
 }


### PR DESCRIPTION
This PR introduces multi-state queries and a state snapshotter. 

**CHANGELOG**
- Now `Decision` can have one or more `StateQuery`s.
-  Adds Postgres Snapshotter for `StateQuery`s
-  Rust doc improvements
- Refactoring and small fixes