### PR TITLE
Rename attribute group to stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ To add Disintegrate to your project, follow these steps:
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Clone, PartialEq, Eq, Event, Serialize, Deserialize)]
-    #[group(UserEvent, [UserCreated])]
-    #[group(CartEvent, [ItemAdded, ItemRemoved, ItemUpdated, CouponApplied])]
-    #[group(CouponEvent, [CouponEmitted, CouponApplied])]
+    #[stream(UserEvent, [UserCreated])]
+    #[stream(CartEvent, [ItemAdded, ItemRemoved, ItemUpdated, CouponApplied])]
+    #[stream(CouponEvent, [CouponEmitted, CouponApplied])]
     pub enum DomainEvent {
         UserCreated {
             #[id]
@@ -141,9 +141,9 @@ To add Disintegrate to your project, follow these steps:
     }
     ```
 
-    In this example, we define an enum `DomainEvent` using the `#[derive(Event)]` attribute. The enum represents various events that can occur in your application. The `#[group]` attribute specifies the event groups, such as `UserEvent` and `CartEvent`, and their corresponding variants. This allows you to organize events into logical groups. The `#[id]` attribute on fields allows you to specify the domain identifiers of each event, which are used for filtering relevant events for a state query.
+    In this example, we define an enum `DomainEvent` using the `#[derive(Event)]` attribute. The enum represents various events that can occur in your application. The `#[stream]` attribute specifies the event streams, such as `UserEvent` and `CartEvent`, and their corresponding variants. This allows you to organize events into logical streams. The `#[id]` attribute on fields allows you to specify the domain identifiers of each event, which are used for filtering relevant events for a state query.
 
-3. Create a state query for constructing a view from events by deriving the `StateQuery` trait. To achieve this, define the event group using the `#[state_query]` attribute and annotate fields containing identifiers with `#[id]`. The library uses the annotated IDs to filter events in the specified group, retaining only those with corresponding IDs. The state must also implement the `StateMutate` trait, which defines how the data contained in the events is aggregated to construct the state:
+3. Create a state query for constructing a view from events by deriving the `StateQuery` trait. To achieve this, define the event stream using the `#[state_query]` attribute and annotate fields containing identifiers with `#[id]`. The library uses the annotated IDs to filter events in the specified stream, retaining only those with corresponding IDs. The state must also implement the `StateMutate` trait, which defines how the data contained in the events is aggregated to construct the state:
 
     ```rust,ignore
     use crate::event::{CartEvent, CouponEvent, DomainEvent};

--- a/disintegrate-macros/src/event.rs
+++ b/disintegrate-macros/src/event.rs
@@ -1,6 +1,6 @@
-mod group;
+mod stream;
 
-use group::{groups, impl_group};
+use stream::{streams, impl_stream};
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{AngleBracketedGenericArguments, Data, DeriveInput, Error, Result};
@@ -13,12 +13,12 @@ pub fn event_inner(ast: &DeriveInput) -> Result<TokenStream> {
     match ast.data {
         Data::Enum(ref data) => {
             let derive_event = impl_enum(ast, data)?;
-            let groups = groups(ast)?;
-            let impl_groups = groups
+            let streams = streams(ast)?;
+            let impl_streams = streams
                 .iter()
-                .map(|g| impl_group(ast, g))
+                .map(|g| impl_stream(ast, g))
                 .collect::<Result<Vec<TokenStream>>>()?;
-            let derive_event_groups = groups
+            let derive_event_streams = streams
                 .iter()
                 .map(|g| {
                     if let Data::Enum(ref enum_data) = g.data {
@@ -31,8 +31,8 @@ pub fn event_inner(ast: &DeriveInput) -> Result<TokenStream> {
 
             Ok(quote! {
                   #derive_event
-                  #(#impl_groups)*
-                  #(#derive_event_groups)*
+                  #(#impl_streams)*
+                  #(#derive_event_streams)*
             })
         }
         Data::Struct(ref data) => impl_struct(ast, data),

--- a/disintegrate-macros/src/lib.rs
+++ b/disintegrate-macros/src/lib.rs
@@ -15,7 +15,7 @@ use syn::{parse_macro_input, DeriveInput};
 /// trait, the enum gains the necessary functionality to be used as an event.
 ///
 /// The `Event` trait can be customized using attributes. The `id` attribute can be used to specify
-/// the domain identifier of an event, while the `group` attribute can be used to group related
+/// the domain identifier of an event, while the `stream` attribute can be used to stream related
 /// events together.
 ///
 /// # Example
@@ -24,8 +24,8 @@ use syn::{parse_macro_input, DeriveInput};
 /// use disintegrate::Event;
 ///
 /// #[derive(Event)]
-/// #[group(UserEvent, [UserRegistered, UserUpdated])]
-/// #[group(OrderEvent, [OrderCreated, OrderCancelled])]
+/// #[stream(UserEvent, [UserRegistered, UserUpdated])]
+/// #[stream(OrderEvent, [OrderCreated, OrderCancelled])]
 /// enum DomainEvent{
 ///     UserCreated {
 ///         #[id]
@@ -51,9 +51,9 @@ use syn::{parse_macro_input, DeriveInput};
 /// ```
 ///
 /// In this example, the `OrderEvent` enum is marked as an event by deriving the `Event` trait. The
-/// `#[group]` attribute specifies the event group name and the list of variants to include in the group, while the `#[id]` attribute is used
+/// `#[stream]` attribute specifies the event stream name and the list of variants to include in the stream, while the `#[id]` attribute is used
 /// to specify the domain identifiers of each variant.
-#[proc_macro_derive(Event, attributes(group, id))]
+#[proc_macro_derive(Event, attributes(stream, id))]
 pub fn event(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
     event::event_inner(&ast)

--- a/disintegrate-macros/tests/event.rs
+++ b/disintegrate-macros/tests/event.rs
@@ -14,8 +14,8 @@ struct UserDeleted {
 }
 
 #[derive(Event, Debug, PartialEq, Eq)]
-#[group(UserEvent, [UserCreated, UserUpdated, UserDeleted])]
-#[group(OrderEvent, [OrderCreated, OrderCancelled])]
+#[stream(UserEvent, [UserCreated, UserUpdated, UserDeleted])]
+#[stream(OrderEvent, [OrderCreated, OrderCancelled])]
 enum DomainEvent {
     UserCreated {
         #[id]
@@ -88,7 +88,7 @@ fn it_returns_correct_domain_identifiers() {
 }
 
 #[test]
-fn it_generates_event_groups() {
+fn it_generates_event_streams() {
     let user_event = UserEvent::UserCreated {
         user_id: "user123".to_string(),
         name: "John Doe".to_string(),

--- a/examples/banking/src/domain.rs
+++ b/examples/banking/src/domain.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, Event, Serialize, Deserialize)]
-#[group(AccountStateEvent, [AccountOpened, AccountClosed])]
-#[group(AccountBalanceEvent, [AmountDeposited, AmountWithdrawn, TransferSent, TransferReceived])]
+#[stream(AccountStateEvent, [AccountOpened, AccountClosed])]
+#[stream(AccountBalanceEvent, [AmountDeposited, AmountWithdrawn, TransferSent, TransferReceived])]
 pub enum DomainEvent {
     AccountOpened {
         #[id]

--- a/examples/cart/src/event.rs
+++ b/examples/cart/src/event.rs
@@ -3,9 +3,9 @@ use disintegrate::Event;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Event, Serialize, Deserialize)]
-#[group(UserEvent, [UserCreated])]
-#[group(CartEvent, [ItemAdded, ItemRemoved, ItemUpdated, CouponApplied])]
-#[group(CouponEvent, [CouponEmitted, CouponApplied])]
+#[stream(UserEvent, [UserCreated])]
+#[stream(CartEvent, [ItemAdded, ItemRemoved, ItemUpdated, CouponApplied])]
+#[stream(CouponEvent, [CouponEmitted, CouponApplied])]
 pub enum DomainEvent {
     UserCreated {
         #[id]

--- a/examples/courses/src/domain.rs
+++ b/examples/courses/src/domain.rs
@@ -9,11 +9,11 @@ pub use subscription::{SubscribeStudent, SubscriptionError};
 pub use unsubscription::{UnsubscribeStudent, UnsubscriptionError};
 
 #[derive(Debug, Clone, PartialEq, Eq, Event)]
-#[group(CourseSubscriptionEvent, [CourseCreated, CourseClosed, StudentSubscribed, StudentUnsubscribed])]
-#[group(StudentSubscriptionEvent, [StudentSubscribed, StudentUnsubscribed, StudentRegistered])]
-#[group(UnsubscriptionEvent, [StudentSubscribed, StudentUnsubscribed])]
-#[group(CourseEvent, [CourseCreated, CourseClosed, CourseRenamed])]
-#[group(StudentEvent, [StudentRegistered])]
+#[stream(CourseSubscriptionEvent, [CourseCreated, CourseClosed, StudentSubscribed, StudentUnsubscribed])]
+#[stream(StudentSubscriptionEvent, [StudentSubscribed, StudentUnsubscribed, StudentRegistered])]
+#[stream(UnsubscriptionEvent, [StudentSubscribed, StudentUnsubscribed])]
+#[stream(CourseEvent, [CourseCreated, CourseClosed, CourseRenamed])]
+#[stream(StudentEvent, [StudentRegistered])]
 pub enum DomainEvent {
     CourseCreated {
         #[id]


### PR DESCRIPTION
This pull request renames the event attribute `group` to `stream`. The term `stream` aligns more effectively with the concept and is commonly utilized in literature.