### PR TITLE
Allow Creation of Postgres Components Without Database Initialization

### DIFF
--- a/disintegrate-postgres/src/lib.rs
+++ b/disintegrate-postgres/src/lib.rs
@@ -9,7 +9,7 @@ pub use crate::event_store::PgEventStore;
 #[cfg(feature = "listener")]
 pub use crate::listener::{PgEventListener, PgEventListenerConfig};
 pub use crate::snapshotter::PgSnapshotter;
-use disintegrate::{DecisionMaker, Event, EventSourcedStateStore, NoSnapshot, WithSnapshot};
+use disintegrate::{DecisionMaker, Event, EventSourcedStateStore, SnapshotConfig, WithSnapshot};
 use disintegrate_serde::Serde;
 pub use error::Error;
 
@@ -22,44 +22,23 @@ pub type PgDecisionMaker<E, S, SN> =
 /// An alias for [`WithSnapshot`], specialized for Postgres.
 pub type WithPgSnapshot = WithSnapshot<PgEventId, PgSnapshotter>;
 
-/// Creates a decision maker specialized for Postgres with snapshotting.
-/// The `every` parameter determines the frequency of snapshot creation, indicating the number of events
-/// between consecutive snapshots.
+/// Creates a decision maker specialized for PostgreSQL.
 ///
 /// # Arguments
 ///
 /// - `event_store`: An instance of `PgEventStore`.
-/// - `every`: The frequency of snapshot creation, specified as the number of events between consecutive snapshots.
+/// - `snapshot_config`: The `SnapshotConfig` to be used for the snapshotting.
 ///
 /// # Returns
 ///
-/// A `PgDecisionMaker` with snapshotting configured using the provided snapshot frequency.
-pub async fn decision_maker_with_snapshot<
+/// A `PgDecisionMaker` with snapshotting configured according to the provided `snapshot_config`.
+pub fn decision_maker<
     E: Event + Send + Sync + Clone,
     S: Serde<E> + Clone + Sync + Send,
+    SN: SnapshotConfig + Clone,
 >(
     event_store: PgEventStore<E, S>,
-    every: u64,
-) -> Result<PgDecisionMaker<E, S, WithPgSnapshot>, Error> {
-    let pool = event_store.pool.clone();
-    let snapshot = WithSnapshot::new(PgSnapshotter::new(pool, every).await?);
-    Ok(DecisionMaker::new(EventSourcedStateStore::new(
-        event_store,
-        snapshot,
-    )))
-}
-
-/// Creates a decision maker specialized for Postgres without snapshotting.
-///
-/// # Arguments
-///
-/// - `event_store`: An instance of `PgEventStore`.
-///
-/// # Returns
-///
-/// A `PgDecisionMaker` without snapshotting.
-pub fn decision_maker<E: Event + Send + Sync + Clone, S: Serde<E> + Clone + Sync + Send>(
-    event_store: PgEventStore<E, S>,
-) -> PgDecisionMaker<E, S, NoSnapshot> {
-    DecisionMaker::new(EventSourcedStateStore::new(event_store, NoSnapshot))
+    snapshot_config: SN,
+) -> PgDecisionMaker<E, S, SN> {
+    DecisionMaker::new(EventSourcedStateStore::new(event_store, snapshot_config))
 }

--- a/disintegrate-postgres/src/snapshotter.rs
+++ b/disintegrate-postgres/src/snapshotter.rs
@@ -28,7 +28,7 @@ pub struct PgSnapshotter {
 }
 
 impl PgSnapshotter {
-    /// Creates a new instance of `PgSnapshotter` with the specified PostgreSQL connection pool and snapshot frequency.
+    /// Creates and initializes a new instance of `PgSnapshotter` with the specified PostgreSQL connection pool and snapshot frequency.
     ///
     /// # Arguments
     ///
@@ -40,7 +40,27 @@ impl PgSnapshotter {
     /// A new `PgSnapshotter` instance.
     pub async fn new(pool: PgPool, every: u64) -> Result<Self, Error> {
         setup(&pool).await?;
-        Ok(Self { pool, every })
+        Ok(Self::new_uninitialized(pool, every))
+    }
+
+    /// Creates a new instance of `PgSnapshotter` with the specified PostgreSQL connection pool and snapshot frequency.
+    ///
+    /// This constructor does not initialize the database. If you need to initialize the database,
+    /// use `PgSnapshotter::new` instead.
+    ///
+    /// If you use this constructor, ensure that the database is already initialized.
+    /// Refer to the SQL files in the `snapshotter/sql` folder for the necessary schema.
+    ///
+    /// # Arguments
+    ///
+    /// - `pool`: A PostgreSQL connection pool (`PgPool`) representing the database connection.
+    /// - `every`: The frequency of snapshot creation, defined as the number of events between consecutive snapshots.
+    ///
+    /// # Returns
+    ///
+    /// A new `PgSnapshotter` instance.
+    pub fn new_uninitialized(pool: PgPool, every: u64) -> Self {
+        Self { pool, every }
     }
 }
 

--- a/examples/cart/src/main.rs
+++ b/examples/cart/src/main.rs
@@ -5,7 +5,7 @@ use cart::AddItem;
 use event::DomainEvent;
 
 use anyhow::{Ok, Result};
-use disintegrate::serde::json::Json;
+use disintegrate::{serde::json::Json, NoSnapshot};
 use disintegrate_postgres::PgEventStore;
 use sqlx::{postgres::PgConnectOptions, PgPool};
 
@@ -24,7 +24,7 @@ async fn main() -> Result<()> {
     let event_store = PgEventStore::new(pool, serde).await?;
 
     // Create a Postgres DecisionMaker
-    let decision_maker = disintegrate_postgres::decision_maker(event_store);
+    let decision_maker = disintegrate_postgres::decision_maker(event_store, NoSnapshot);
 
     // Make the decision. This performs the business decision and persists the changes into the
     // event store


### PR DESCRIPTION
This PR introduces new constructors that enable users to create PostgreSQL components, avoiding the initialization of the database.