### PR TITLE
Append without validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "disintegrate"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "assert2",
  "async-stream",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "disintegrate-macros"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "disintegrate",
  "heck 0.5.0",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "disintegrate-postgres"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "disintegrate-serde"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "apache-avro",
  "prost 0.13.3",

--- a/README.md
+++ b/README.md
@@ -69,16 +69,16 @@ To add Disintegrate to your project, follow these steps:
 
     ```toml
     [dependencies]
-    disintegrate = "1.0.0"
-    disintegrate-postgres = "1.0.0"
+    disintegrate = "2.0.0"
+    disintegrate-postgres = "2.0.0"
     ```
 
     * Disintegrate provides several features that you can enable based on your project requirements. You can include them in your `Cargo.toml` file as follows:
 
     ```toml
     [dependencies]
-    disintegrate = { version = "1.0.0", features = ["macros", "serde-prost"] }
-    disintegrate-postgres = { version = "1.0.0", features = ["listener"] }
+    disintegrate = { version = "2.0.0", features = ["macros", "serde-prost"] }
+    disintegrate-postgres = { version = "2.0.0", features = ["listener"] }
     ```
 
     * The macros feature enables the use of derive macros to simplify events implementations.
@@ -90,7 +90,7 @@ To add Disintegrate to your project, follow these steps:
         * To enable Prost serialization, use the `serde-prost` feature: `features = ["serde-prost"]`.
         * To enable Protocol Buffers serialization, use the `serde-protobuf` feature: `features = ["serde-protobuf"]`.
 
-    * If you're using the PostgreSQL event store backend and want to use the listener mechanism, you can enable the `listener` feature: `disintegrate-postgres = {version = "1.0.0", features = ["listener"]}`.
+    * If you're using the PostgreSQL event store backend and want to use the listener mechanism, you can enable the `listener` feature: `disintegrate-postgres = {version = "2.0.0", features = ["listener"]}`.
 
 2. Define the list of events in your application. You can use the Event Storming technique to identify the events that occur in your system. Here's an example of defining events using Disintegrate:
 

--- a/disintegrate-macros/Cargo.toml
+++ b/disintegrate-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "disintegrate-macros"
 description = "Disintegrate macros. Not for direct use. Refer to the `disintegrate` crate for details."
-version = "1.0.0"
+version = "2.0.0"
 license.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -21,4 +21,4 @@ quote = "1.0.33"
 syn = { version = "2.0.65", features = ["full"] }
 
 [dev-dependencies]
-disintegrate = { version = "1.0.0", path = "../disintegrate", features = ["macros"] }
+disintegrate = { version = "2.0.0", path = "../disintegrate", features = ["macros"] }

--- a/disintegrate-postgres/Cargo.toml
+++ b/disintegrate-postgres/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "disintegrate-postgres"
 description = "Disintegrate PostgresDB implementation. Not for direct use. Refer to the `disintegrate` crate for details."
-version = "1.0.0"
+version = "2.0.0"
 license.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -13,9 +13,9 @@ default = []
 listener = ["dep:tokio", "dep:tokio-util"]
 
 [dependencies]
-disintegrate = { version = "1.0.0", path = "../disintegrate" }
-disintegrate-serde = { version = "1.0.0", path = "../disintegrate-serde" }
-disintegrate-macros = { version = "1.0.0", path = "../disintegrate-macros" }
+disintegrate = { version = "2.0.0", path = "../disintegrate" }
+disintegrate-serde = { version = "2.0.0", path = "../disintegrate-serde" }
+disintegrate-macros = { version = "2.0.0", path = "../disintegrate-macros" }
 serde = "1.0.196"
 serde_json = "1.0.114"
 sqlx = { version = "0.8.2", features = ["postgres", "runtime-tokio-rustls", "uuid"] }
@@ -30,4 +30,4 @@ md-5 = "0.10.6"
 paste = "1.0.14"
 
 [dev-dependencies]
-disintegrate-serde = { version = "1.0.0", path = "../disintegrate-serde", features = ["json"] }
+disintegrate-serde = { version = "2.0.0", path = "../disintegrate-serde", features = ["json"] }

--- a/disintegrate-postgres/src/event_store.rs
+++ b/disintegrate-postgres/src/event_store.rs
@@ -204,7 +204,7 @@ where
 
     /// Appends a batch of events to the PostgreSQL-backed event store **without** verifying  
     /// whether new events have been added since the last read.  
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `events` - A vector of events to be appended.
@@ -213,7 +213,10 @@ where
     ///
     /// A `Result` containing a vector of `PersistedEvent` representing the appended events,
     /// or an error of type `Self::Error`.
-    async fn append_unchecked(&self, events: Vec<E>) -> Result<Vec<PersistedEvent<PgEventId, E>>, Self::Error>
+    async fn append_unchecked(
+        &self,
+        events: Vec<E>,
+    ) -> Result<Vec<PersistedEvent<PgEventId, E>>, Self::Error>
     where
         E: Clone + 'async_trait,
     {

--- a/disintegrate-postgres/src/event_store.rs
+++ b/disintegrate-postgres/src/event_store.rs
@@ -213,7 +213,7 @@ where
     ///
     /// A `Result` containing a vector of `PersistedEvent` representing the appended events,
     /// or an error of type `Self::Error`.
-    async fn append_unchecked(
+    async fn append_without_validation(
         &self,
         events: Vec<E>,
     ) -> Result<Vec<PersistedEvent<PgEventId, E>>, Self::Error>

--- a/disintegrate-postgres/src/event_store/insert_builder.rs
+++ b/disintegrate-postgres/src/event_store/insert_builder.rs
@@ -16,6 +16,7 @@ where
     event: &'a E,
     id: Option<PgEventId>,
     payload: Option<&'a [u8]>,
+    consumed: Option<bool>,
     returning: Option<&'a str>,
 }
 
@@ -35,6 +36,7 @@ where
             event,
             id: None,
             payload: None,
+            consumed: None,
             returning: None,
         }
     }
@@ -56,6 +58,16 @@ where
     /// * `payload` - The payload of the event.
     pub fn with_payload(mut self, payload: &'a [u8]) -> Self {
         self.payload = Some(payload);
+        self
+    }
+
+    /// Sets the consumed flag for the event to be inserted.
+    ///
+    /// # Arguments
+    ///
+    /// * `consumed` - The value for the consumed flag.
+    pub fn with_consumed(mut self, consumed: bool) -> Self {
+        self.consumed = Some(consumed);
         self
     }
 
@@ -88,6 +100,10 @@ where
             separated_builder.push("payload");
         }
 
+        if self.consumed.is_some() {
+            separated_builder.push("consumed");
+        }
+
         separated_builder.push_unseparated(") VALUES (");
 
         separated_builder.push_bind_unseparated(self.event.name());
@@ -108,6 +124,10 @@ where
 
         if let Some(payload) = self.payload {
             separated_builder.push_bind(payload);
+        }
+
+        if let Some(consumed) = self.consumed {
+            separated_builder.push(if consumed { 1 } else { 0 });
         }
 
         separated_builder.push_unseparated(")");

--- a/disintegrate-postgres/src/event_store/tests.rs
+++ b/disintegrate-postgres/src/event_store/tests.rs
@@ -149,7 +149,7 @@ async fn it_appends_unchecked(pool: PgPool) {
         removed_event("product_2", "cart_1"),
     ];
 
-    event_store.append_unchecked(events).await.unwrap();
+    event_store.append_without_validation(events).await.unwrap();
 
     let stored_events = sqlx::query("SELECT event_id, event_type, payload FROM event")
         .fetch_all(&pool)

--- a/disintegrate-serde/Cargo.toml
+++ b/disintegrate-serde/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "disintegrate-serde"
 description = "Serialization and deserializaion library for Disintegrate event store. Not for direct use. Refer to the `disintegrate` crate for details."
-version = "1.0.0"
+version = "2.0.0"
 license.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/disintegrate/Cargo.toml
+++ b/disintegrate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "disintegrate"
 description = "Disintegrate is a Rust library to build event-sourced applications."
-version = "1.0.0"
+version = "2.0.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
@@ -22,8 +22,8 @@ futures = "0.3.30"
 lazy_static = "1.4.0"
 regex = "1.10.5"
 serde = { version = "1.0.196", features = ["derive"] }
-disintegrate-serde = { version = "1.0.0", path = "../disintegrate-serde", optional = true }
-disintegrate-macros = { version = "1.0.0", path = "../disintegrate-macros", optional = true }
+disintegrate-serde = { version = "2.0.0", path = "../disintegrate-serde", optional = true }
+disintegrate-macros = { version = "2.0.0", path = "../disintegrate-macros", optional = true }
 thiserror = "1.0.61"
 mockall = "0.12.1"
 paste = "1.0.14"

--- a/disintegrate/src/event_store.rs
+++ b/disintegrate/src/event_store.rs
@@ -69,4 +69,29 @@ where
     where
         E: Clone + 'async_trait,
         QE: Event + 'static + Clone + Send + Sync;
+
+    /// Appends a batch of events to the event store **without** verifying if  
+    /// new events have been added since the last read.  
+    ///
+    /// This method is useful when you are certain that no other process  
+    /// has modified the event store in a way that would make your logic stale.  
+    /// Additionally, it does **not** check for duplicates, which may occur  
+    /// if the append operation is triggered from an **at-least-once delivery** mechanism.  
+    ///
+    /// If you need to guarantee that no duplicate events are added,  
+    /// use the `append` method instead, providing a query that ensures uniqueness.  
+    ///
+    /// # Arguments
+    ///
+    /// * `events` - A vector of events to append to the event store.
+    ///
+    ///# Returns
+    ///
+    /// A `Result` containing a vector of `PersistedEvent` representing the appended events, or an error.
+    async fn append_unchecked(
+        &self,
+        events: Vec<E>,
+    ) -> Result<Vec<PersistedEvent<ID, E>>, Self::Error>
+    where
+        E: Clone + 'async_trait;
 }

--- a/disintegrate/src/event_store.rs
+++ b/disintegrate/src/event_store.rs
@@ -75,8 +75,6 @@ where
     ///
     /// This method is useful when you are certain that no other process  
     /// has modified the event store in a way that would make your logic stale.  
-    /// Additionally, it does **not** check for duplicates, which may occur  
-    /// if the append operation is triggered from an **at-least-once delivery** mechanism.  
     ///
     /// If you need to guarantee that no duplicate events are added,  
     /// use the `append` method instead, providing a query that ensures uniqueness.  

--- a/disintegrate/src/event_store.rs
+++ b/disintegrate/src/event_store.rs
@@ -86,7 +86,7 @@ where
     ///# Returns
     ///
     /// A `Result` containing a vector of `PersistedEvent` representing the appended events, or an error.
-    async fn append_unchecked(
+    async fn append_without_validation(
         &self,
         events: Vec<E>,
     ) -> Result<Vec<PersistedEvent<ID, E>>, Self::Error>

--- a/disintegrate/src/utils.rs
+++ b/disintegrate/src/utils.rs
@@ -325,7 +325,7 @@ pub mod tests {
             query: StreamQuery<i64, QE>,
             last_event_id: i64,
         ) -> Vec<PersistedEvent<i64, ShoppingCartEvent>>;
-        fn append_unchecked(
+        fn append_without_validation(
             &self,
             events: Vec<ShoppingCartEvent>,
         ) -> Vec<PersistedEvent<i64, ShoppingCartEvent>>;
@@ -346,7 +346,7 @@ pub mod tests {
                 last_event_id: i64,
             ) -> Vec<PersistedEvent<i64, ShoppingCartEvent>>;
 
-            fn append_unchecked(&self, events: Vec<ShoppingCartEvent>) -> Vec<PersistedEvent<i64, ShoppingCartEvent>>;
+            fn append_without_validation(&self, events: Vec<ShoppingCartEvent>) -> Vec<PersistedEvent<i64, ShoppingCartEvent>>;
         }
         impl Clone for Database {
             fn clone(&self) -> Self;
@@ -380,11 +380,11 @@ pub mod tests {
             Ok(self.database.append(events, query, last_event_id))
         }
 
-        async fn append_unchecked(
+        async fn append_without_validation(
             &self,
             events: Vec<ShoppingCartEvent>,
         ) -> Result<Vec<PersistedEvent<i64, ShoppingCartEvent>>, Self::Error> {
-            Ok(self.database.append_unchecked(events))
+            Ok(self.database.append_without_validation(events))
         }
     }
     #[derive(Default, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]

--- a/disintegrate/src/utils.rs
+++ b/disintegrate/src/utils.rs
@@ -325,22 +325,28 @@ pub mod tests {
             query: StreamQuery<i64, QE>,
             last_event_id: i64,
         ) -> Vec<PersistedEvent<i64, ShoppingCartEvent>>;
+        fn append_unchecked(
+            &self,
+            events: Vec<ShoppingCartEvent>,
+        ) -> Vec<PersistedEvent<i64, ShoppingCartEvent>>;
     }
 
     mock! {
         pub Database {}
         impl Database for Database {
-        fn stream<QE: Event + Clone + 'static + Send + Sync>(
-            &self,
-            query: &StreamQuery<i64, QE>,
-        ) -> Vec<Result<PersistedEvent<i64, QE>, Error>>;
+            fn stream<QE: Event + Clone + 'static + Send + Sync>(
+                &self,
+                query: &StreamQuery<i64, QE>,
+            ) -> Vec<Result<PersistedEvent<i64, QE>, Error>>;
 
-        fn append<QE: Event + Clone + 'static + Send + Sync>(
-            &self,
-            events: Vec<ShoppingCartEvent>,
-            query: StreamQuery<i64, QE>,
-            last_event_id: i64,
-        ) -> Vec<PersistedEvent<i64, ShoppingCartEvent>>;
+            fn append<QE: Event + Clone + 'static + Send + Sync>(
+                &self,
+                events: Vec<ShoppingCartEvent>,
+                query: StreamQuery<i64, QE>,
+                last_event_id: i64,
+            ) -> Vec<PersistedEvent<i64, ShoppingCartEvent>>;
+
+            fn append_unchecked(&self, events: Vec<ShoppingCartEvent>) -> Vec<PersistedEvent<i64, ShoppingCartEvent>>;
         }
         impl Clone for Database {
             fn clone(&self) -> Self;
@@ -372,6 +378,13 @@ pub mod tests {
             QE: Event + 'static + Clone + Send + Sync,
         {
             Ok(self.database.append(events, query, last_event_id))
+        }
+
+        async fn append_unchecked(
+            &self,
+            events: Vec<ShoppingCartEvent>,
+        ) -> Result<Vec<PersistedEvent<i64, ShoppingCartEvent>>, Self::Error> {
+            Ok(self.database.append_unchecked(events))
         }
     }
     #[derive(Default, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]

--- a/examples/banking/Cargo.toml
+++ b/examples/banking/Cargo.toml
@@ -8,8 +8,8 @@ authors.workspace = true
 repository.workspace = true
 
 [dependencies]
-disintegrate = { version = "1.0.0", path = "../../disintegrate", features = ["macros", "serde-json"] }
-disintegrate-postgres = { version = "1.0.0", path = "../../disintegrate-postgres" }
+disintegrate = { version = "2.0.0", path = "../../disintegrate", features = ["macros", "serde-json"] }
+disintegrate-postgres = { version = "2.0.0", path = "../../disintegrate-postgres" }
 tokio = { version = "1.42.0", features = ["macros", "rt-multi-thread", "signal"] }
 serde = { version = "1.0.196", features = ["derive"] }
 thiserror = "1.0.61"

--- a/examples/cart/Cargo.toml
+++ b/examples/cart/Cargo.toml
@@ -8,8 +8,8 @@ authors.workspace = true
 repository.workspace = true
 
 [dependencies]
-disintegrate = { version = "1.0.0", path = "../../disintegrate", features = ["macros", "serde-json"] }
-disintegrate-postgres = { version = "1.0.0", path = "../../disintegrate-postgres" }
+disintegrate = { version = "2.0.0", path = "../../disintegrate", features = ["macros", "serde-json"] }
+disintegrate-postgres = { version = "2.0.0", path = "../../disintegrate-postgres" }
 sqlx = { version = "0.8.2", features = [ "runtime-tokio-rustls" , "postgres" ] }
 tokio = { version = "1.42.0", features = ["macros", "rt-multi-thread", "signal"] }
 anyhow = "1.0.94"

--- a/examples/courses/Cargo.toml
+++ b/examples/courses/Cargo.toml
@@ -10,8 +10,8 @@ repository.workspace = true
 [dependencies]
 anyhow = "1.0.94"
 async-trait = "0.1.80"
-disintegrate = {version = "1.0.0", path = "../../disintegrate", features = ["macros", "serde-prost"] }
-disintegrate-postgres = { version = "1.0.0", path = "../../disintegrate-postgres", features = ["listener"] }
+disintegrate = {version = "2.0.0", path = "../../disintegrate", features = ["macros", "serde-prost"] }
+disintegrate-postgres = { version = "2.0.0", path = "../../disintegrate-postgres", features = ["listener"] }
 rust_decimal = "1.35.0"
 sqlx = { version = "0.8.2", features = [ "runtime-tokio-rustls" , "postgres" ] }
 thiserror = "1.0.61"

--- a/examples/courses/Cargo.toml
+++ b/examples/courses/Cargo.toml
@@ -8,10 +8,10 @@ authors.workspace = true
 repository.workspace = true
 
 [dependencies]
-anyhow = "1.0.94"
-async-trait = "0.1.80"
 disintegrate = {version = "2.0.0", path = "../../disintegrate", features = ["macros", "serde-prost"] }
 disintegrate-postgres = { version = "2.0.0", path = "../../disintegrate-postgres", features = ["listener"] }
+anyhow = "1.0.94"
+async-trait = "0.1.80"
 rust_decimal = "1.35.0"
 sqlx = { version = "0.8.2", features = [ "runtime-tokio-rustls" , "postgres" ] }
 thiserror = "2.0.11"


### PR DESCRIPTION
This PR introduces the append without validation method. This method allows to append events to the event store without verifying whether new events have been added since the last read.