### PR TITLE
Re-export messagepack

### DIFF
--- a/disintegrate-serde/src/serde/messagepack.rs
+++ b/disintegrate-serde/src/serde/messagepack.rs
@@ -30,10 +30,7 @@ where
     /// # Returns
     ///
     /// Serialized bytes representing the value in MessagePack format.
-    fn serialize(
-        &self,
-        value: T,
-    ) -> Vec<u8> {
+    fn serialize(&self, value: T) -> Vec<u8> {
         rmp_serde::to_vec(&value).expect("MessagePack serialization failed")
     }
 }
@@ -51,10 +48,7 @@ where
     /// # Returns
     ///
     /// A `Result` containing the deserialized value on success, or an error on failure.
-    fn deserialize(
-        &self,
-        data: Vec<u8>,
-    ) -> Result<T, Error> {
+    fn deserialize(&self, data: Vec<u8>) -> Result<T, Error> {
         rmp_serde::from_slice(&data).map_err(|e| Error::Deserialization(Box::new(e)))
     }
 }

--- a/disintegrate/Cargo.toml
+++ b/disintegrate/Cargo.toml
@@ -11,8 +11,9 @@ license.workspace = true
 [features]
 macros = ["disintegrate-macros"]
 serde = ["disintegrate-serde"]
-serde-json = ["serde", "disintegrate-serde/json"]
 serde-avro = ["serde", "disintegrate-serde/avro"]
+serde-json = ["serde", "disintegrate-serde/json"]
+serde-messagepack = ["serde", "disintegrate-serde/messagepack"]
 serde-prost = ["serde", "disintegrate-serde/prost"]
 serde-protobuf = ["serde", "disintegrate-serde/protobuf"]
 

--- a/disintegrate/src/lib.rs
+++ b/disintegrate/src/lib.rs
@@ -52,6 +52,9 @@ pub mod serde {
     #[cfg(feature = "serde-json")]
     #[doc(inline)]
     pub use disintegrate_serde::serde::json;
+    #[cfg(feature = "serde-messagepack")]
+    #[doc(inline)]
+    pub use disintegrate_serde::serde::messagepack;
     #[cfg(feature = "serde-prost")]
     #[doc(inline)]
     pub use disintegrate_serde::serde::prost;


### PR DESCRIPTION
This PR re-export `messagepack` and add the `serde-messagepack` feature.